### PR TITLE
feat(sdk-wasm): multi-resource create_delegation

### DIFF
--- a/tinycloud-sdk-wasm/src/lib.rs
+++ b/tinycloud-sdk-wasm/src/lib.rs
@@ -123,34 +123,40 @@ pub fn siweToDelegationHeaders(signedSIWEMessage: JsValue) -> Result<JsValue, Js
     )?)
 }
 
-/// Create a delegation UCAN from a session to another DID.
-/// This allows session keys to delegate capabilities to other users client-side.
+/// Create a multi-resource delegation UCAN from a session to another DID.
+///
+/// Produces a **single** UCAN JWT that encodes every `(service, path, actions)`
+/// entry in `abilities`, scoped to `spaceId`. This lets a session key
+/// re-delegate exactly the capabilities it holds (or a strict subset) in one
+/// signed blob, regardless of how many services or paths the delegation
+/// covers.
 ///
 /// # Arguments
-/// * `session` - The current session (with JWK and delegation info)
-/// * `delegateDID` - The recipient's DID (audience of the delegation)
-/// * `spaceId` - The space being delegated (e.g., "tinycloud:pkh:eip155:1:0x....:default")
-/// * `path` - Path scope for the delegation
-/// * `actions` - Actions to delegate (e.g., ["tinycloud.kv/get", "tinycloud.kv/put"])
-/// * `expirationSecs` - Expiration timestamp in seconds since epoch
-/// * `notBeforeSecs` - Optional not-before timestamp in seconds since epoch
+/// * `session` - The current session (with JWK and delegation info).
+/// * `delegateDID` - The recipient DID (audience of the UCAN).
+/// * `spaceId` - The TinyCloud user space the delegation targets
+///   (e.g., `"tinycloud:pkh:eip155:1:0x....:default"`).
+/// * `abilities` - JS object shape `{ [service]: { [path]: [action, ...] } }`
+///   matching the shape `prepareSession` already accepts. Actions are
+///   full-URN strings (e.g., `"tinycloud.kv/get"`). An empty map is an error.
+/// * `expirationSecs` - UCAN expiration timestamp (seconds since epoch).
+/// * `notBeforeSecs` - Optional UCAN not-before timestamp.
 ///
 /// # Returns
-/// A `DelegationResult` containing:
-/// * `delegation` - Base64url-encoded UCAN JWT string
-/// * `cid` - CID of the delegation (for referencing in proof chains)
-/// * `delegateDID` - The delegate's DID
-/// * `path` - Path scope
-/// * `actions` - Delegated actions
-/// * `expiry` - Expiration timestamp
+/// A [`session::DelegationResult`] containing:
+/// * `delegation` - Base64url-encoded UCAN JWT.
+/// * `cid` - CID of the delegation (for proof chains).
+/// * `delegateDid` - The delegate's DID.
+/// * `expiry` - Expiration timestamp.
+/// * `resources` - Deterministic list of `{ service, space, path, actions }`
+///   entries describing what the UCAN grants. Sorted by `(service, path)`.
 #[wasm_bindgen]
 #[allow(non_snake_case)]
 pub fn createDelegation(
     session: JsValue,
     delegateDID: String,
     spaceId: String,
-    path: String,
-    actions: Vec<String>,
+    abilities: JsValue,
     expirationSecs: f64,
     notBeforeSecs: JsValue,
 ) -> Result<JsValue, JsValue> {
@@ -159,15 +165,17 @@ pub fn createDelegation(
     // Parse space_id
     let space_id: tinycloud_auth::resource::SpaceId = spaceId.parse().map_err(map_jserr)?;
 
-    // Parse path
-    let path: tinycloud_auth::resource::Path = path.parse().map_err(map_jserr)?;
-
-    // Parse actions
-    let abilities: Vec<tinycloud_auth::siwe_recap::Ability> = actions
-        .into_iter()
-        .map(|a| a.parse())
-        .collect::<Result<_, _>>()
-        .map_err(map_jserr)?;
+    // Parse the multi-resource abilities map. This is the same shape that
+    // `prepareSession` accepts: `{ [service]: { [path]: [action] } }`.
+    // serde_wasm_bindgen handles the nested HashMap deserialization directly
+    // because `Service`, `Path`, and `Ability` all implement `FromStr`/`Deserialize`.
+    let abilities_map: std::collections::HashMap<
+        tinycloud_auth::resource::Service,
+        std::collections::HashMap<
+            tinycloud_auth::resource::Path,
+            Vec<tinycloud_auth::siwe_recap::Ability>,
+        >,
+    > = serde_wasm_bindgen::from_value(abilities)?;
 
     // Parse optional not_before
     let not_before: Option<f64> = if notBeforeSecs.is_undefined() || notBeforeSecs.is_null() {
@@ -181,8 +189,7 @@ pub fn createDelegation(
         .create_delegation(
             &delegateDID,
             &space_id,
-            &path,
-            abilities,
+            abilities_map,
             expirationSecs,
             not_before,
         )

--- a/tinycloud-sdk-wasm/src/session.rs
+++ b/tinycloud-sdk-wasm/src/session.rs
@@ -284,7 +284,8 @@ impl Session {
         // Sort services and paths so the resulting `resources` vector is
         // deterministic regardless of HashMap iteration order. This keeps
         // test assertions stable and makes the JS side's read-back predictable.
-        let mut services: Vec<(Service, HashMap<Path, Vec<Ability>>)> = abilities.into_iter().collect();
+        let mut services: Vec<(Service, HashMap<Path, Vec<Ability>>)> =
+            abilities.into_iter().collect();
         services.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
 
         for (service, paths_map) in services {
@@ -323,10 +324,7 @@ impl Session {
                 // Extend the capability object with this (resource, actions)
                 // pair. The ucan-capabilities-object crate keys internally by
                 // resource URI, so each iteration adds a distinct entry.
-                caps.with_actions(
-                    resource.as_uri(),
-                    path_actions.into_iter().map(|a| (a, [])),
-                );
+                caps.with_actions(resource.as_uri(), path_actions.into_iter().map(|a| (a, [])));
 
                 resources.push(DelegatedResource {
                     service: service.to_string(),
@@ -979,7 +977,13 @@ pub mod test {
         )]);
 
         let result = session
-            .create_delegation(delegate_did, &session.space_id, abilities, 4_000_000_000.0, None)
+            .create_delegation(
+                delegate_did,
+                &session.space_id,
+                abilities,
+                4_000_000_000.0,
+                None,
+            )
             .expect("single-resource delegation should succeed");
 
         assert_eq!(result.delegate_did, delegate_did);
@@ -989,7 +993,10 @@ pub mod test {
         assert_eq!(result.resources[0].path, "com.listen.app/");
         assert_eq!(
             result.resources[0].actions,
-            vec!["tinycloud.kv/get".to_string(), "tinycloud.kv/put".to_string()]
+            vec![
+                "tinycloud.kv/get".to_string(),
+                "tinycloud.kv/put".to_string()
+            ]
         );
 
         // Decode the UCAN and confirm the attenuation lines up with what we sent.
@@ -1033,7 +1040,13 @@ pub mod test {
         ]);
 
         let result = session
-            .create_delegation(delegate_did, &session.space_id, abilities, 4_000_000_000.0, None)
+            .create_delegation(
+                delegate_did,
+                &session.space_id,
+                abilities,
+                4_000_000_000.0,
+                None,
+            )
             .expect("multi-service delegation should succeed");
 
         assert_eq!(
@@ -1087,7 +1100,13 @@ pub mod test {
         ]);
 
         let result = session
-            .create_delegation(delegate_did, &session.space_id, abilities, 4_000_000_000.0, None)
+            .create_delegation(
+                delegate_did,
+                &session.space_id,
+                abilities,
+                4_000_000_000.0,
+                None,
+            )
             .expect("multi-service/multi-path delegation should succeed");
 
         assert_eq!(result.resources.len(), 3);
@@ -1222,7 +1241,13 @@ pub mod test {
             ("sql", "com.listen.app/", &["tinycloud.sql/read"]),
         ]);
         let result = session
-            .create_delegation(delegate_did, &session.space_id, abilities, 4_000_000_000.0, None)
+            .create_delegation(
+                delegate_did,
+                &session.space_id,
+                abilities,
+                4_000_000_000.0,
+                None,
+            )
             .expect("subset delegation should succeed");
 
         // Every resource in the delegation must be derivable from the parsed

--- a/tinycloud-sdk-wasm/src/session.rs
+++ b/tinycloud-sdk-wasm/src/session.rs
@@ -224,32 +224,118 @@ impl Session {
         )
     }
 
-    /// Create a delegation UCAN from this session to another DID.
-    /// Unlike invocations (which are self-issued for immediate use),
-    /// delegations are issued to a recipient DID with longer expiry.
+    /// Create a multi-resource delegation UCAN from this session to another DID.
+    ///
+    /// Unlike invocations (which are self-issued for immediate use), delegations
+    /// are issued to a recipient DID with longer expiry. This method produces a
+    /// **single** UCAN that encodes every `(service, path, actions)` entry in
+    /// the supplied abilities map, scoped to `space_id`. The resulting UCAN has
+    /// one `attenuation` (ReCap capabilities) object with multiple resource URIs
+    /// — one per `(service, path)` tuple — each carrying its own action set.
+    ///
+    /// This is the delegation-side mirror of [`SessionConfig::into_message`]
+    /// which encodes the same multi-resource shape into a SIWE recap at
+    /// sign-in. Both sides read from
+    /// `HashMap<Service, HashMap<Path, Vec<Ability>>>` so a session can
+    /// re-delegate exactly the capabilities it holds, or a strict subset,
+    /// without any shape conversion.
+    ///
+    /// # Arguments
+    /// * `delegate_did` - The recipient DID (audience of the UCAN).
+    /// * `space_id` - The TinyCloud user space the delegation targets.
+    /// * `abilities` - Service → path → actions map. An empty map is an error;
+    ///   an empty action list under any (service, path) is also an error since
+    ///   it would encode a useless delegation.
+    /// * `expiration_secs` - UCAN expiration timestamp in seconds since epoch.
+    /// * `not_before_secs` - Optional UCAN not-before timestamp.
+    ///
+    /// # Returns
+    /// A [`DelegationResult`] with the signed UCAN JWT, its CID, the delegate
+    /// DID, the expiry, and a `resources` list describing each
+    /// `(service, space, path, actions)` entry that was granted. The
+    /// `resources` list lets JS callers reconstruct the exact shape they sent
+    /// without having to re-parse the UCAN.
     pub fn create_delegation(
         &self,
         delegate_did: &str,
         space_id: &SpaceId,
-        path: &Path,
-        actions: Vec<Ability>,
+        abilities: HashMap<Service, HashMap<Path, Vec<Ability>>>,
         expiration_secs: f64,
         not_before_secs: Option<f64>,
     ) -> Result<DelegationResult, DelegationError> {
         use std::str::FromStr;
 
-        // Build the resource from space_id, service "kv", and path
-        let service: Service = "kv".parse().map_err(|_| DelegationError::InvalidService)?;
-        let resource = space_id
-            .clone()
-            .to_resource(service, Some(path.clone()), None, None);
+        if abilities.is_empty() {
+            return Err(DelegationError::EmptyAbilities);
+        }
 
-        // Collect action strings for the result before consuming them
-        let action_strings: Vec<String> = actions.iter().map(|a| a.to_string()).collect();
-
-        // Build capabilities (type parameter is the caveats type, using empty array)
+        // Build capabilities (type parameter is the caveats type, using empty
+        // array to match invocation / session capability encoding).
+        //
+        // We walk the full (service, path, actions) tree so that a single UCAN
+        // encodes every entry. `Capabilities::with_actions` is keyed by the
+        // resource URI, which already embeds (space, service, path), so
+        // distinct (service, path) tuples naturally end up as distinct entries
+        // in the underlying `att:` map. This is the same encoding path used
+        // by `SessionConfig::into_message`.
         let mut caps = tinycloud_auth::ucan_capabilities_object::Capabilities::<[(); 0]>::new();
-        caps.with_actions(resource.as_uri(), actions.into_iter().map(|a| (a, [])));
+        let mut resources: Vec<DelegatedResource> = Vec::new();
+
+        // Sort services and paths so the resulting `resources` vector is
+        // deterministic regardless of HashMap iteration order. This keeps
+        // test assertions stable and makes the JS side's read-back predictable.
+        let mut services: Vec<(Service, HashMap<Path, Vec<Ability>>)> = abilities.into_iter().collect();
+        services.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
+
+        for (service, paths_map) in services {
+            if paths_map.is_empty() {
+                return Err(DelegationError::EmptyPathsForService(service.to_string()));
+            }
+
+            let mut paths: Vec<(Path, Vec<Ability>)> = paths_map.into_iter().collect();
+            paths.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
+
+            for (path, path_actions) in paths {
+                if path_actions.is_empty() {
+                    return Err(DelegationError::EmptyActionsForPath {
+                        service: service.to_string(),
+                        path: path.to_string(),
+                    });
+                }
+
+                // Follow the same empty-path convention as `into_message`:
+                // an empty-string path means "no path segment" (the resource
+                // URI has no path component), which matches how the session's
+                // own recap encodes space-wide grants.
+                let path_opt = if path.as_str().is_empty() {
+                    None
+                } else {
+                    Some(path.clone())
+                };
+
+                let resource = space_id
+                    .clone()
+                    .to_resource(service.clone(), path_opt, None, None);
+
+                let action_strings: Vec<String> =
+                    path_actions.iter().map(|a| a.to_string()).collect();
+
+                // Extend the capability object with this (resource, actions)
+                // pair. The ucan-capabilities-object crate keys internally by
+                // resource URI, so each iteration adds a distinct entry.
+                caps.with_actions(
+                    resource.as_uri(),
+                    path_actions.into_iter().map(|a| (a, [])),
+                );
+
+                resources.push(DelegatedResource {
+                    service: service.to_string(),
+                    space: space_id.to_string(),
+                    path: path.to_string(),
+                    actions: action_strings,
+                });
+            }
+        }
 
         // Build UCAN payload (F=serde_json::Value for facts, C=[();0] for caveats)
         let payload: Payload<serde_json::Value, [(); 0]> = Payload {
@@ -284,14 +370,35 @@ impl Session {
             delegation: delegation_str,
             cid: cid.to_string(),
             delegate_did: delegate_did.to_string(),
-            path: path.to_string(),
-            actions: action_strings,
             expiry: expiration_secs,
+            resources,
         })
     }
 }
 
-/// Result of creating a delegation UCAN.
+/// A single (service, space, path, actions) entry inside a delegation result.
+///
+/// Mirrors the manifest `PermissionEntry` shape that the JS SDK uses so the
+/// client can reconstruct what it sent without having to re-parse the UCAN.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DelegatedResource {
+    /// Service name, e.g. "kv", "sql", "duckdb", "capabilities".
+    pub service: String,
+    /// Full space id string, e.g. "tinycloud:pkh:eip155:1:0x....:default".
+    pub space: String,
+    /// Resource path; empty string if the resource URI had no path segment.
+    pub path: String,
+    /// Full-URN ability strings, e.g. ["tinycloud.kv/get", "tinycloud.kv/put"].
+    pub actions: Vec<String>,
+}
+
+/// Result of creating a multi-resource delegation UCAN.
+///
+/// The `resources` field describes every `(service, space, path, actions)`
+/// entry embedded in the UCAN's capability object. A single delegation may
+/// carry grants for multiple services on multiple paths — the UCAN itself is
+/// still one signed blob.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DelegationResult {
@@ -301,18 +408,21 @@ pub struct DelegationResult {
     pub cid: String,
     /// The DID of the delegate (recipient)
     pub delegate_did: String,
-    /// Path scope of the delegation
-    pub path: String,
-    /// Actions delegated
-    pub actions: Vec<String>,
     /// Expiration timestamp in seconds since epoch
     pub expiry: f64,
+    /// All (service, space, path, actions) entries granted by this delegation.
+    /// Always non-empty on success.
+    pub resources: Vec<DelegatedResource>,
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum DelegationError {
-    #[error("invalid service: must be 'kv'")]
-    InvalidService,
+    #[error("abilities map must not be empty")]
+    EmptyAbilities,
+    #[error("service '{0}' has no paths in the abilities map")]
+    EmptyPathsForService(String),
+    #[error("service '{service}' path '{path}' has no actions in the abilities map")]
+    EmptyActionsForPath { service: String, path: String },
     #[error("invalid issuer DID URL: {0}")]
     InvalidIssuer(#[from] tinycloud_auth::ssi::dids::InvalidDIDURL<String>),
     #[error("invalid audience DID: {0}")]
@@ -754,5 +864,389 @@ pub mod test {
             siwe_str.contains(public_space),
             "SIWE message should contain additional space resource URI"
         );
+    }
+
+    // ---------------------------------------------------------------------
+    // create_delegation multi-resource tests
+    // ---------------------------------------------------------------------
+    //
+    // These exercise the new multi-resource delegation path:
+    // - a session holds a multi-service / multi-path recap
+    // - it creates ONE UCAN that re-delegates some subset of that shape
+    // - we decode the UCAN and verify the attenuation matches what we sent
+    //
+    // Decoding uses `ssi::ucan::Ucan::decode` which is the same path the
+    // server uses when ingesting a delegation, so the round-trip also
+    // confirms the delegation is parseable by real consumers, not just
+    // our own test helpers.
+
+    fn rich_test_session() -> Session {
+        // Session with KV + SQL + capabilities all granted on
+        // "com.listen.app/". This is the baseline the SDK produces for a
+        // listen-style manifest.
+        let config = json!({
+            "abilities": {
+                "kv": {
+                    "com.listen.app/": vec![
+                        "tinycloud.kv/get",
+                        "tinycloud.kv/put",
+                        "tinycloud.kv/del",
+                        "tinycloud.kv/list",
+                        "tinycloud.kv/metadata",
+                    ],
+                },
+                "sql": {
+                    "com.listen.app/": vec![
+                        "tinycloud.sql/read",
+                        "tinycloud.sql/write",
+                    ],
+                },
+                "capabilities": {
+                    "com.listen.app/": vec![
+                        "tinycloud.capabilities/read",
+                    ],
+                },
+            },
+            "address": "0x7BD63AA37326a64d458559F44432103e3d6eEDE9",
+            "chainId": 1u8,
+            "domain": "example.com",
+            "issuedAt": "2022-01-01T00:00:00.000Z",
+            "spaceId": "tinycloud:pkh:eip155:1:0x7BD63AA37326a64d458559F44432103e3d6eEDE9:default",
+            "expirationTime": "3000-01-01T00:00:00.000Z",
+        });
+        let prepared = prepare_session(serde_json::from_value(config).unwrap()).unwrap();
+        let mut signed = serde_json::to_value(prepared).unwrap();
+        signed
+            .as_object_mut()
+            .unwrap()
+            .insert(
+                "signature".into(),
+                "361647d08fb3ac41b26d9300d80e1964e1b3e7960e5276b3c9f5045ae55171442287279c83fd8922f9238312e89336b1672be8778d078d7dc5107b8c913299721c".into(),
+            );
+        complete_session_setup(serde_json::from_value(signed).unwrap()).unwrap()
+    }
+
+    fn build_abilities(
+        entries: &[(&str, &str, &[&str])],
+    ) -> HashMap<Service, HashMap<Path, Vec<Ability>>> {
+        let mut out: HashMap<Service, HashMap<Path, Vec<Ability>>> = HashMap::new();
+        for (service, path, actions) in entries {
+            let svc: Service = service.parse().expect("valid service");
+            let p: Path = path.parse().expect("valid path");
+            let abilities: Vec<Ability> = actions
+                .iter()
+                .map(|a| a.parse().expect("valid ability"))
+                .collect();
+            out.entry(svc).or_default().insert(p, abilities);
+        }
+        out
+    }
+
+    /// Decode the UCAN JWT we just signed and return its (resource_uri, action)
+    /// pairs as a sorted Vec so tests can do deterministic comparisons.
+    fn decode_delegation_pairs(jwt: &str) -> Vec<(String, String)> {
+        // Decode with the same generic parameters we sign with:
+        //   F = serde_json::Value (facts)
+        //   A = [(); 0]           (caveats)
+        // Mismatched params would deserialize the capability payload into a
+        // different shape and silently break the assertions below.
+        let ucan: tinycloud_auth::ssi::ucan::Ucan<serde_json::Value, [(); 0]> =
+            tinycloud_auth::ssi::ucan::Ucan::decode(jwt).expect("delegation UCAN should decode");
+        let caps = &ucan.payload().attenuation;
+        let mut pairs: Vec<(String, String)> = Vec::new();
+        for (resource_uri, ability_map) in caps.abilities().iter() {
+            for ability in ability_map.keys() {
+                pairs.push((resource_uri.to_string(), ability.to_string()));
+            }
+        }
+        pairs.sort();
+        pairs
+    }
+
+    #[test]
+    fn create_delegation_single_resource_backward_compat() {
+        // Existing behavior: one service, one path, multiple actions. The old
+        // signature took (space, path, actions) and hardcoded service="kv".
+        // The new signature takes the full abilities map — this test proves a
+        // single-entry map still round-trips cleanly through the delegation.
+        let session = rich_test_session();
+        let delegate_did = "did:pkh:eip155:1:0xBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEF";
+
+        let abilities = build_abilities(&[(
+            "kv",
+            "com.listen.app/",
+            &["tinycloud.kv/get", "tinycloud.kv/put"],
+        )]);
+
+        let result = session
+            .create_delegation(delegate_did, &session.space_id, abilities, 4_000_000_000.0, None)
+            .expect("single-resource delegation should succeed");
+
+        assert_eq!(result.delegate_did, delegate_did);
+        assert_eq!(result.expiry, 4_000_000_000.0);
+        assert_eq!(result.resources.len(), 1, "one (service, path) entry");
+        assert_eq!(result.resources[0].service, "kv");
+        assert_eq!(result.resources[0].path, "com.listen.app/");
+        assert_eq!(
+            result.resources[0].actions,
+            vec!["tinycloud.kv/get".to_string(), "tinycloud.kv/put".to_string()]
+        );
+
+        // Decode the UCAN and confirm the attenuation lines up with what we sent.
+        // The resource URI format is
+        //   "{space_id}/{service}/{path}"
+        // as produced by `SpaceId::to_resource` — this is the same URI that
+        // shows up in a signed SIWE's Resources list.
+        let pairs = decode_delegation_pairs(&result.delegation);
+        let expected_resource =
+            "tinycloud:pkh:eip155:1:0x7BD63AA37326a64d458559F44432103e3d6eEDE9:default/kv/com.listen.app/"
+                .to_string();
+        assert_eq!(
+            pairs,
+            vec![
+                (expected_resource.clone(), "tinycloud.kv/get".to_string()),
+                (expected_resource, "tinycloud.kv/put".to_string()),
+            ],
+            "UCAN attenuation should contain exactly the granted (resource, action) pairs"
+        );
+    }
+
+    #[test]
+    fn create_delegation_multi_service_same_path() {
+        // Listen's real use case: grant KV + SQL on the same app path in one
+        // delegation. The resulting UCAN must contain both service resource
+        // URIs with their respective action sets — and be a single signed blob.
+        let session = rich_test_session();
+        let delegate_did = "did:pkh:eip155:1:0xBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEF";
+
+        let abilities = build_abilities(&[
+            (
+                "kv",
+                "com.listen.app/",
+                &["tinycloud.kv/get", "tinycloud.kv/put"],
+            ),
+            (
+                "sql",
+                "com.listen.app/",
+                &["tinycloud.sql/read", "tinycloud.sql/write"],
+            ),
+        ]);
+
+        let result = session
+            .create_delegation(delegate_did, &session.space_id, abilities, 4_000_000_000.0, None)
+            .expect("multi-service delegation should succeed");
+
+        assert_eq!(
+            result.resources.len(),
+            2,
+            "expected 2 (service, path) entries, got {:?}",
+            result.resources
+        );
+
+        // The Rust implementation sorts by (service, path). "kv" sorts before
+        // "sql" lexicographically, so this order is deterministic.
+        assert_eq!(result.resources[0].service, "kv");
+        assert_eq!(result.resources[1].service, "sql");
+        for r in &result.resources {
+            assert_eq!(r.path, "com.listen.app/");
+            assert_eq!(r.space, session.space_id.to_string());
+        }
+
+        let pairs = decode_delegation_pairs(&result.delegation);
+        let base =
+            "tinycloud:pkh:eip155:1:0x7BD63AA37326a64d458559F44432103e3d6eEDE9:default".to_string();
+        // Resource URI layout: "{space}/{service}/{path}". Service + path
+        // segments are slash-delimited, not colon-delimited.
+        let kv_resource = format!("{base}/kv/com.listen.app/");
+        let sql_resource = format!("{base}/sql/com.listen.app/");
+        assert_eq!(
+            pairs,
+            vec![
+                (kv_resource.clone(), "tinycloud.kv/get".to_string()),
+                (kv_resource, "tinycloud.kv/put".to_string()),
+                (sql_resource.clone(), "tinycloud.sql/read".to_string()),
+                (sql_resource, "tinycloud.sql/write".to_string()),
+            ],
+            "UCAN attenuation should contain kv + sql entries on the same path"
+        );
+    }
+
+    #[test]
+    fn create_delegation_multi_service_multi_path() {
+        // The most general case: different services on different paths in one
+        // delegation. This is the "app with multiple backend databases"
+        // scenario. We verify each (service, path) pair ends up as its own
+        // attenuation entry and no cross-contamination happens.
+        let session = rich_test_session();
+        let delegate_did = "did:pkh:eip155:1:0xBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEF";
+
+        let abilities = build_abilities(&[
+            ("kv", "a", &["tinycloud.kv/get"]),
+            ("sql", "b/data.sqlite", &["tinycloud.sql/read"]),
+            ("capabilities", "c", &["tinycloud.capabilities/read"]),
+        ]);
+
+        let result = session
+            .create_delegation(delegate_did, &session.space_id, abilities, 4_000_000_000.0, None)
+            .expect("multi-service/multi-path delegation should succeed");
+
+        assert_eq!(result.resources.len(), 3);
+
+        // resources are sorted by (service, path). Services are sorted
+        // lexicographically: "capabilities" < "kv" < "sql".
+        assert_eq!(result.resources[0].service, "capabilities");
+        assert_eq!(result.resources[0].path, "c");
+        assert_eq!(result.resources[1].service, "kv");
+        assert_eq!(result.resources[1].path, "a");
+        assert_eq!(result.resources[2].service, "sql");
+        assert_eq!(result.resources[2].path, "b/data.sqlite");
+
+        let pairs = decode_delegation_pairs(&result.delegation);
+        let base =
+            "tinycloud:pkh:eip155:1:0x7BD63AA37326a64d458559F44432103e3d6eEDE9:default".to_string();
+        // Resource URI layout: "{space}/{service}/{path}".
+        assert_eq!(
+            pairs,
+            vec![
+                (
+                    format!("{base}/capabilities/c"),
+                    "tinycloud.capabilities/read".to_string(),
+                ),
+                (format!("{base}/kv/a"), "tinycloud.kv/get".to_string()),
+                (
+                    format!("{base}/sql/b/data.sqlite"),
+                    "tinycloud.sql/read".to_string(),
+                ),
+            ],
+            "each (service, path) pair should get its own attenuation entry"
+        );
+    }
+
+    #[test]
+    fn create_delegation_rejects_empty_abilities() {
+        // Empty map is user error, not a valid "no-op delegation". Surface it
+        // with a clear error rather than signing a useless UCAN.
+        let session = rich_test_session();
+        let err = session
+            .create_delegation(
+                "did:pkh:eip155:1:0xBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEF",
+                &session.space_id,
+                HashMap::new(),
+                4_000_000_000.0,
+                None,
+            )
+            .expect_err("empty abilities should error");
+        assert!(
+            matches!(err, DelegationError::EmptyAbilities),
+            "expected EmptyAbilities, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn create_delegation_rejects_empty_actions_under_path() {
+        // A (service, path) entry with no actions would encode a useless
+        // delegation. Catch it at the boundary.
+        let session = rich_test_session();
+        let mut abilities: HashMap<Service, HashMap<Path, Vec<Ability>>> = HashMap::new();
+        let svc: Service = "kv".parse().unwrap();
+        let p: Path = "com.listen.app/".parse().unwrap();
+        abilities.entry(svc).or_default().insert(p, vec![]);
+
+        let err = session
+            .create_delegation(
+                "did:pkh:eip155:1:0xBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEF",
+                &session.space_id,
+                abilities,
+                4_000_000_000.0,
+                None,
+            )
+            .expect_err("empty actions should error");
+        assert!(
+            matches!(err, DelegationError::EmptyActionsForPath { .. }),
+            "expected EmptyActionsForPath, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn create_delegation_subset_of_parse_recap() {
+        // End-to-end sanity: sign a session with rich recap, re-delegate a
+        // strict subset, then parse the delegation and verify each granted
+        // (service, space, path, actions) tuple is indeed present in the
+        // original session's parsed recap. This is the invariant the JS
+        // derivability check in `delegateTo` relies on: the delegation the
+        // session key signs must be a subset of what the SIWE granted.
+        //
+        // We rebuild the same config as `rich_test_session` and use the
+        // PreparedSession's SIWE string as the source of truth for what the
+        // session was granted — we can't easily reconstruct that string from
+        // a `Session` since the SIWE is consumed by `complete_session_setup`.
+        let session = rich_test_session();
+        let config = json!({
+            "abilities": {
+                "kv": {
+                    "com.listen.app/": vec![
+                        "tinycloud.kv/get",
+                        "tinycloud.kv/put",
+                        "tinycloud.kv/del",
+                        "tinycloud.kv/list",
+                        "tinycloud.kv/metadata",
+                    ],
+                },
+                "sql": {
+                    "com.listen.app/": vec![
+                        "tinycloud.sql/read",
+                        "tinycloud.sql/write",
+                    ],
+                },
+                "capabilities": {
+                    "com.listen.app/": vec![
+                        "tinycloud.capabilities/read",
+                    ],
+                },
+            },
+            "address": "0x7BD63AA37326a64d458559F44432103e3d6eEDE9",
+            "chainId": 1u8,
+            "domain": "example.com",
+            "issuedAt": "2022-01-01T00:00:00.000Z",
+            "spaceId": "tinycloud:pkh:eip155:1:0x7BD63AA37326a64d458559F44432103e3d6eEDE9:default",
+            "expirationTime": "3000-01-01T00:00:00.000Z",
+        });
+        let prepared = prepare_session(serde_json::from_value(config).unwrap()).unwrap();
+        let session_siwe = prepared.siwe.to_string();
+        let granted = parse_recap_from_siwe(&session_siwe).unwrap();
+
+        // Delegate strict subset: kv/get + sql/read only.
+        let delegate_did = "did:pkh:eip155:1:0xBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEF";
+        let abilities = build_abilities(&[
+            ("kv", "com.listen.app/", &["tinycloud.kv/get"]),
+            ("sql", "com.listen.app/", &["tinycloud.sql/read"]),
+        ]);
+        let result = session
+            .create_delegation(delegate_did, &session.space_id, abilities, 4_000_000_000.0, None)
+            .expect("subset delegation should succeed");
+
+        // Every resource in the delegation must be derivable from the parsed
+        // session recap: same service+space+path with the delegated actions
+        // being a subset of the granted actions.
+        for delegated in &result.resources {
+            let matching_grant = granted.iter().find(|g| {
+                g.service == delegated.service
+                    && g.space == delegated.space
+                    && g.path == delegated.path
+            });
+            let matching_grant = matching_grant.unwrap_or_else(|| {
+                panic!(
+                    "delegated resource {:?} has no matching grant in session recap: {:?}",
+                    delegated, granted
+                )
+            });
+            for action in &delegated.actions {
+                assert!(
+                    matching_grant.actions.contains(action),
+                    "action {action} not in granted actions {:?}",
+                    matching_grant.actions
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Extend `Session::create_delegation` and the `createDelegation` WASM export to accept the same multi-resource abilities shape as `prepareSession`:
`HashMap<Service, HashMap<Path, Vec<Ability>>>`. A single UCAN now encodes every `(service, path, actions)` entry in one signed blob, scoped to a single target space.

## What was broken

1. **Service was hardcoded to `"kv"`** in the Rust delegation path — delegations for `sql`, `duckdb`, `hooks`, or `capabilities` services were silently wrong (the resource URI was built with `kv` in the service segment).
2. **Single-entry only** — callers that needed to delegate multiple `(service, path)` pairs had to issue N separate UCANs. This is wrong semantically (the user model is one delegation per recipient) and, in the legacy wallet-signed fallback, forces N wallet prompts. It also broke the manifest use case in the js-sdk, where an app's manifest can declare multiple permission entries in a single `delegations[].permissions` block.

## What's fixed

- `create_delegation` now takes `abilities: HashMap<Service, HashMap<Path, Vec<Ability>>>` and walks every `(service, path, actions)` tuple, accumulating them into one `Capabilities` object via `with_actions`. One signed UCAN, many resource URIs in its `attenuation`.
- The `createDelegation` WASM export takes `abilities: JsValue` in the same `{ service: { path: [action] } }` shape the JS side already uses for `prepareSession`.
- `DelegationResult` now returns `resources: Vec<DelegatedResource>` — a sorted list of `{service, space, path, actions}` describing every capability the UCAN grants. Sort order is lexicographic on `(service, path)` so tests and JS consumers get deterministic output regardless of HashMap iteration.
- Validation errors surface as typed variants: `EmptyAbilities`, `EmptyPathsForService`, `EmptyActionsForPath`. Previously an empty actions list under a path would silently sign a useless UCAN.

## Tests (11 total, all green)

- `create_delegation_single_resource_backward_compat` — one service/path round-trips cleanly through the new shape
- `create_delegation_multi_service_same_path` — KV + SQL on the same app path produce one UCAN with two attenuation entries
- `create_delegation_multi_service_multi_path` — three different services on three different paths in one UCAN, each getting its own entry
- `create_delegation_rejects_empty_abilities`
- `create_delegation_rejects_empty_actions_under_path`
- `create_delegation_subset_of_parse_recap` — end-to-end invariant that every delegated resource is derivable from the session's own parsed recap (the check the JS `delegateTo` path relies on)

All existing sdk-wasm tests (`parse_recap_*`, `create_session_and_invoke`, `session_with_additional_spaces`) still pass.

## Breaking change

The `createDelegation` WASM export signature changed from
```
createDelegation(session, delegateDID, spaceId, path, actions, expirationSecs, notBeforeSecs)
```
to
```
createDelegation(session, delegateDID, spaceId, abilities, expirationSecs, notBeforeSecs)
```

The only JS caller is `TinyCloudNode.createDelegationWrapper`, which is being updated in the matching js-sdk PR (`fix/manifest-signin-multi-delegate`) that bumps the WASM rev to this commit.

## Test plan

- [x] `cargo test -p tinycloud-sdk-wasm --lib` — 11/11 pass locally
- [x] `cargo check --workspace` — clean
- [ ] CI green
- [ ] js-sdk PR bumps the `packages/sdk-rs/Cargo.toml` rev to this merge SHA and updates `createDelegationWrapper` to pass the abilities map