### PR TITLE
fix(ci): always run release-plz release job

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -34,10 +34,6 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    # Only run when a release PR is merged (detects version bump commits)
-    if: >
-      github.event_name == 'push' &&
-      startsWith(github.event.head_commit.message, 'chore(release)')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The `release` job in `.github/workflows/release-plz.yml` was gated on:

```yaml
if: >
  github.event_name == 'push' &&
  startsWith(github.event.head_commit.message, 'chore(release)')
```

But release-plz creates release PRs with commit messages that start with `chore(<package-name>)`, not `chore(release)`. The most recent release PR (#51) merged with the commit message:

> `chore(tinycloud-node): release v1.3.0 (#51)`

So the gate never matched, the `release` job never ran, and as a result:
- no git tag was created for v1.3.0
- nothing was published to crates.io
- no binaries were built
- no Phala deploy was triggered

Cargo.toml is at v1.3.0 but the release never actually shipped.

## Fix

Remove the `if:` gate from the `release` job entirely.

This is safe because release-plz's `release` command is **idempotent**: it inspects `Cargo.toml` and crates.io and only publishes if the local version is newer than what's already published. Running it on every push to `main` (or via `workflow_dispatch`) is the documented usage pattern.

## Result

- `release-plz` job: still creates release PRs on push to main / manual dispatch (unchanged)
- `release` job: now runs on every push to main and on `workflow_dispatch`
- `CARGO_REGISTRY_TOKEN` is still passed to the release step
- Once this is merged, the next push to main will publish v1.3.0 to crates.io and tag it

## Test plan

- [ ] Merge this PR
- [ ] Confirm the `release` job runs on the resulting push to main
- [ ] Confirm v1.3.0 is published to crates.io and a `v1.3.0` git tag is created
- [ ] Confirm downstream Phala deploy is triggered