### PR TITLE
fix(release): skip crates.io, use cargo-dist installers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
     "tinycloud-auth",
@@ -64,7 +65,7 @@ targets = [
     "aarch64-apple-darwin",
 ]
 # Installers to generate
-installers = []
+installers = ["shell", "powershell"]
 # Whether to auto-include README/LICENSE/CHANGELOG
 auto-includes = true
 # Enable cargo-binstall support (generates binstall metadata in GitHub releases)

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -3,9 +3,16 @@
 release_commits = "^(feat|fix|chore|refactor|perf|docs|ci|test)(\\(.*\\))?!?:"
 
 # Only release the server binary — internal crates are not published
+# TODO: when ready to publish to crates.io, publish all internal workspace
+# crates (tinycloud-auth, tinycloud-core, dependencies/siwe, siwe-recap,
+# cacao) with versioned deps so this can resolve. The crates.io name
+# `tinycloud-node` is reserved separately via a placeholder publish.
 [[package]]
 name = "tinycloud-node"
-publish = true
+# Skipping crates.io until internal workspace crates (tinycloud-auth,
+# tinycloud-core, dependencies/*) are also published with versioned deps.
+# Binary distribution happens via GitHub Releases + cargo-dist installers.
+publish = false
 git_release_enable = true
 git_tag_enable = true
 git_tag_name = "v{{ version }}"


### PR DESCRIPTION
## Why

The crates.io publish failed because `tinycloud-node-server`'s path deps (e.g. `tinycloud-auth`) lack version specifiers. Publishing the binary requires publishing all internal workspace crates first. We're deferring that.

## Changes

- `release-plz.toml`: `publish = false` for `tinycloud-node` (stops the failed publish loop)
- `Cargo.toml`: enable cargo-dist shell + powershell installers, add `workspace.resolver = "2"` to silence resolver warning
- Comments documenting future intent to publish to crates.io

## Result

- Git tags + GitHub Releases still work
- Binaries built and attached to releases (4 targets)
- Users can install via shell installer (curl ... | sh) or download .tar.gz
- `cargo install tinycloud-node` won't work until we publish to crates.io
- `cargo install --git` still works (builds from source)

## Next step (separate one-off)

Reserve the `tinycloud-node` name on crates.io by publishing a minimal v0.0.1 placeholder from a temp dir.