### PR TITLE
fix(ci): use PAT for release-plz so tag push triggers downstream workflows

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -28,7 +29,7 @@ jobs:
           command: release-pr
           config: release-plz.toml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   release:
@@ -39,6 +40,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -49,5 +51,5 @@ jobs:
           command: release
           config: release-plz.toml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Why

GitHub does not let workflows triggered by GITHUB_TOKEN create new workflow runs (loop prevention). When release-plz pushed v1.3.0 with the default token, neither release.yml (binaries) nor docker.yml (Phala deploy) fired.

Switching to a fine-grained PAT (RELEASE_PLZ_TOKEN with `contents: write` + `pull-requests: write`) bypasses this restriction.

## Changes

- Both jobs in release-plz.yml now use `RELEASE_PLZ_TOKEN`:
  - `actions/checkout@v4` uses the PAT for git auth
  - The release-plz action uses the PAT as `GITHUB_TOKEN`
- `CARGO_REGISTRY_TOKEN` reference unchanged

## After merging

The next release-plz tag push will trigger release.yml and docker.yml normally.

The existing v1.3.0 tag/release was created with GITHUB_TOKEN so downstream workflows didn't fire. To recover: delete the v1.3.0 tag + release, then re-run release-plz workflow manually. The team lead will handle this separately.