### PR TITLE
fix(deploy): use Rocket-compatible log level in dstack composes

### DIFF
--- a/docker-compose.dstack-full.yaml
+++ b/docker-compose.dstack-full.yaml
@@ -15,7 +15,7 @@ services:
       TINYCLOUD_STORAGE_DATABASE: "postgres://tinycloud:tinycloud@postgres:5432/tinycloud"
       TINYCLOUD_STORAGE_BLOCKS_TYPE: Local
       TINYCLOUD_STORAGE_BLOCKS_PATH: /data/blocks
-      TINYCLOUD_LOG_LEVEL: info
+      TINYCLOUD_LOG_LEVEL: normal
       TINYCLOUD_CORS: "true"
       ROCKET_ADDRESS: "0.0.0.0"
     depends_on:

--- a/docker-compose.dstack-postgres.yaml
+++ b/docker-compose.dstack-postgres.yaml
@@ -23,7 +23,7 @@ services:
       AWS_ACCESS_KEY_ID: "${AWS_KEY}"
       AWS_SECRET_ACCESS_KEY: "${AWS_SECRET}"
       AWS_DEFAULT_REGION: "${AWS_REGION}"
-      TINYCLOUD_LOG_LEVEL: info
+      TINYCLOUD_LOG_LEVEL: normal
       TINYCLOUD_CORS: "true"
       ROCKET_ADDRESS: "0.0.0.0"
 

--- a/docker-compose.dstack.yaml
+++ b/docker-compose.dstack.yaml
@@ -23,7 +23,7 @@ services:
       TINYCLOUD_STORAGE_DATABASE: "sqlite:./data/caps.db?mode=rwc"
       TINYCLOUD_STORAGE_BLOCKS_TYPE: Local
       TINYCLOUD_STORAGE_BLOCKS_PATH: ./data/blocks
-      TINYCLOUD_LOG_LEVEL: info
+      TINYCLOUD_LOG_LEVEL: normal
       TINYCLOUD_CORS: "true"
       ROCKET_ADDRESS: "0.0.0.0"
 


### PR DESCRIPTION
## Why

The prod CVM was crash-looping after the v1.3.0 deploy with:

\`\`\`
called \`Result::unwrap()\` on an \`Err\` value: Config(...
  path: ["log_level"],
  kind: InvalidValue(Str("info"), "one of \`critical\`, \`normal\`, \`debug\`, \`off\`"))
\`\`\`

Rocket uses non-standard log level names. \`info\` isn't valid; \`normal\` is the equivalent.

## Why didn't this surface before?

The previously-running image was a much older build that pre-dated the strict log_level validation. Our v1.3.0 image started enforcing it, exposing this latent misconfiguration.

## Test plan

- After release-plz cuts v1.3.x, the deploy should succeed and prod containers start.
- Verify https://tee.node.tinycloud.xyz/healthz returns 200.