### PR TITLE
feat: TC-1368 Add signed KV URLs 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9249,6 +9249,7 @@ dependencies = [
  "opentelemetry_sdk",
  "pin-project",
  "prometheus",
+ "rand 0.8.5",
  "reqwest 0.11.27",
  "rocket",
  "serde",

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ The SDK checks this endpoint during sign-in and requires an exact protocol versi
 | `GET` | `/version` | No | Protocol version and feature discovery |
 | `POST` | `/invoke` | Yes | Execute KV operations (get, put, list, delete) |
 | `POST` | `/signed/kv` | Yes | Create an expiring signed URL for an exact KV object read |
-| `GET` | `/signed/kv/<space>/<key..>?token=<token>` | Signed URL token | Fetch a KV object through a signed URL |
+| `GET` | `/signed/kv/<ticketId>` | Signed URL ticket | Fetch a KV object through a signed URL |
 | `POST` | `/delegate` | Yes | Create capability delegations |
 | `GET` | `/peer/generate/<space>` | No | Generate space host key pair |
 | `GET` | `/healthz` | No | Health check |
 
 ### Signed KV URLs
 
-`POST /signed/kv` accepts a normal TinyCloud invocation with an exact `tinycloud.kv/get` capability for the requested object. The JSON body is:
+`POST /signed/kv` accepts a normal TinyCloud invocation whose authorized capabilities include a `tinycloud.kv/get` capability that can be attenuated to the requested `{space, path}`. The invocation may include other capabilities. The JSON body is:
 
 ```json
 {
@@ -51,7 +51,19 @@ The SDK checks this endpoint during sign-in and requires an exact protocol versi
 }
 ```
 
-The response includes a relative `url`, bearer `token`, and RFC3339 `expiresAt`. The token is HMAC-signed by the node, scoped to the exact space and path, and expires at the earliest of the requested TTL, the node maximum TTL, the invocation expiry, and the parent delegation expiry. `maxUses` is rejected for now because limited-use URLs need durable server-side state to stay correct across restarts and multi-node deployments.
+The response includes a short relative `url`, opaque `ticketId`, and RFC3339 `expiresAt`:
+
+```json
+{
+  "url": "/signed/kv/JUWkXuA4mqnxDVXcaxXoVME8uYUTumgmuwbllQFxHnQ",
+  "ticketId": "JUWkXuA4mqnxDVXcaxXoVME8uYUTumgmuwbllQFxHnQ",
+  "expiresAt": "2026-05-12T16:25:00Z"
+}
+```
+
+The node stores the ticket durably in its database with the exact KV scope, issuer/subject DID, ability, service, creation and expiry timestamps, parent expiry metadata, optional hash/ETag binding, and proof metadata. The bearer URL does not contain the space, path, or signed claims. Reads load the ticket, validate expiry and scope, then perform a private KV read; signed KV URLs are not limited to public spaces.
+
+Ticket expiry is the earliest of the requested TTL, node maximum TTL, invocation expiry, and parent delegation expiry when known. `maxUses` is rejected in v1 because limited-use URLs need durable counters and replay protection to stay correct across restarts and multi-node deployments.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,25 @@ The SDK checks this endpoint during sign-in and requires an exact protocol versi
 |--------|----------|------|-------------|
 | `GET` | `/version` | No | Protocol version and feature discovery |
 | `POST` | `/invoke` | Yes | Execute KV operations (get, put, list, delete) |
+| `POST` | `/signed/kv` | Yes | Create an expiring signed URL for an exact KV object read |
+| `GET` | `/signed/kv/<space>/<key..>?token=<token>` | Signed URL token | Fetch a KV object through a signed URL |
 | `POST` | `/delegate` | Yes | Create capability delegations |
 | `GET` | `/peer/generate/<space>` | No | Generate space host key pair |
 | `GET` | `/healthz` | No | Health check |
+
+### Signed KV URLs
+
+`POST /signed/kv` accepts a normal TinyCloud invocation with an exact `tinycloud.kv/get` capability for the requested object. The JSON body is:
+
+```json
+{
+  "space": "tinycloud:...",
+  "path": "transcripts/audio.wav",
+  "ttlSeconds": 60
+}
+```
+
+The response includes a relative `url`, bearer `token`, and RFC3339 `expiresAt`. The token is HMAC-signed by the node, scoped to the exact space and path, and expires at the earliest of the requested TTL, the node maximum TTL, the invocation expiry, and the parent delegation expiry. `maxUses` is rejected for now because limited-use URLs need durable server-side state to stay correct across restarts and multi-node deployments.
 
 ## Quickstart
 

--- a/tinycloud-core/src/db.rs
+++ b/tinycloud-core/src/db.rs
@@ -369,6 +369,25 @@ where
             .await
     }
 
+    pub async fn create_signed_kv_ticket(
+        &self,
+        model: signed_kv_ticket::Model,
+    ) -> Result<signed_kv_ticket::Model, DbErr> {
+        signed_kv_ticket::Entity::insert(signed_kv_ticket::ActiveModel::from(model.clone()))
+            .exec(&self.conn)
+            .await?;
+        Ok(model)
+    }
+
+    pub async fn find_signed_kv_ticket(
+        &self,
+        ticket_id: &str,
+    ) -> Result<Option<signed_kv_ticket::Model>, DbErr> {
+        signed_kv_ticket::Entity::find_by_id(ticket_id.to_string())
+            .one(&self.conn)
+            .await
+    }
+
     pub async fn deactivate_hook_subscription(&self, subscription_id: &str) -> Result<(), DbErr> {
         let Some(model) = hook_subscription::Entity::find_by_id(subscription_id.to_string())
             .one(&self.conn)
@@ -408,6 +427,14 @@ where
     B: ImmutableReadStore,
 {
     pub async fn public_kv_get(
+        &self,
+        space_id: &SpaceId,
+        key: &Path,
+    ) -> Result<Option<(Metadata, Hash, Content<B::Readable>)>, EitherError<DbErr, B::Error>> {
+        self.kv_get(space_id, key).await
+    }
+
+    pub async fn kv_get(
         &self,
         space_id: &SpaceId,
         key: &Path,

--- a/tinycloud-core/src/migrations/m20260512_000000_signed_kv_tickets.rs
+++ b/tinycloud-core/src/migrations/m20260512_000000_signed_kv_tickets.rs
@@ -1,0 +1,97 @@
+use sea_orm_migration::prelude::*;
+
+use crate::models::signed_kv_ticket;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(signed_kv_ticket::Entity)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(signed_kv_ticket::Column::Id)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(signed_kv_ticket::Column::IssuerDid)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(signed_kv_ticket::Column::SubjectDid)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(signed_kv_ticket::Column::SpaceId)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(signed_kv_ticket::Column::Path)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(signed_kv_ticket::Column::Service)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(signed_kv_ticket::Column::Ability)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(signed_kv_ticket::Column::CreatedAt)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(signed_kv_ticket::Column::ExpiresAt)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(signed_kv_ticket::Column::InvocationExpiresAt)
+                            .string()
+                            .null(),
+                    )
+                    .col(
+                        ColumnDef::new(signed_kv_ticket::Column::ParentExpiresAt)
+                            .string()
+                            .null(),
+                    )
+                    .col(
+                        ColumnDef::new(signed_kv_ticket::Column::ContentHash)
+                            .string()
+                            .null(),
+                    )
+                    .col(
+                        ColumnDef::new(signed_kv_ticket::Column::Etag)
+                            .string()
+                            .null(),
+                    )
+                    .col(
+                        ColumnDef::new(signed_kv_ticket::Column::ParentCidsJson)
+                            .string()
+                            .null(),
+                    )
+                    .primary_key(Index::create().col(signed_kv_ticket::Column::Id))
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(signed_kv_ticket::Entity).to_owned())
+            .await
+    }
+}

--- a/tinycloud-core/src/migrations/mod.rs
+++ b/tinycloud-core/src/migrations/mod.rs
@@ -2,6 +2,7 @@ use sea_orm_migration::prelude::*;
 pub mod m20230510_101010_init_tables;
 pub mod m20260218_sql_database;
 pub mod m20260409_000000_hook_tables;
+pub mod m20260512_000000_signed_kv_tickets;
 
 pub struct Migrator;
 
@@ -12,6 +13,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20230510_101010_init_tables::Migration),
             Box::new(m20260218_sql_database::Migration),
             Box::new(m20260409_000000_hook_tables::Migration),
+            Box::new(m20260512_000000_signed_kv_tickets::Migration),
         ]
     }
 }

--- a/tinycloud-core/src/models/mod.rs
+++ b/tinycloud-core/src/models/mod.rs
@@ -8,4 +8,5 @@ pub mod invocation;
 pub mod kv_delete;
 pub mod kv_write;
 pub mod revocation;
+pub mod signed_kv_ticket;
 pub mod space;

--- a/tinycloud-core/src/models/signed_kv_ticket.rs
+++ b/tinycloud-core/src/models/signed_kv_ticket.rs
@@ -1,0 +1,26 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "signed_kv_ticket")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false, unique)]
+    pub id: String,
+    pub issuer_did: String,
+    pub subject_did: String,
+    pub space_id: String,
+    pub path: String,
+    pub service: String,
+    pub ability: String,
+    pub created_at: String,
+    pub expires_at: String,
+    pub invocation_expires_at: Option<String>,
+    pub parent_expires_at: Option<String>,
+    pub content_hash: Option<String>,
+    pub etag: Option<String>,
+    pub parent_cids_json: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/tinycloud-node-server/Cargo.toml
+++ b/tinycloud-node-server/Cargo.toml
@@ -33,6 +33,7 @@ opentelemetry_sdk = { version = "0.29.0", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.29.0", features = ["grpc-tonic", "trace"] }
 pin-project = "1"
 prometheus = { version = "0.13.0", features = ["process"] }
+rand = "0.8"
 reqwest = { version = "0.11", features = ["json"] }
 rocket = { version = "0.5.1", features = ["json", "tls", "mtls"] }
 subtle = "2"

--- a/tinycloud-node-server/src/lib.rs
+++ b/tinycloud-node-server/src/lib.rs
@@ -19,6 +19,7 @@ pub mod hooks;
 pub mod prometheus;
 pub mod quota;
 pub mod routes;
+pub mod signed_urls;
 pub mod storage;
 pub mod tee;
 mod tracing;
@@ -30,10 +31,11 @@ use quota::QuotaCache;
 use routes::{
     admin::{delete_quota, get_quota, list_quotas, set_quota},
     attestation::attestation,
-    delegate,
+    create_signed_kv_url, delegate,
     hooks::{create_hook_ticket, create_webhook, delete_webhook, hook_events, list_webhooks},
     info, invoke, open_host_key,
     public::{public_kv_get, public_kv_head, public_kv_list, public_kv_options, RateLimiter},
+    signed_kv_get,
     util_routes::*,
     version,
 };
@@ -113,6 +115,8 @@ pub async fn app(config: &Figment) -> Result<Rocket<Build>> {
         open_host_key,
         invoke,
         delegate,
+        create_signed_kv_url,
+        signed_kv_get,
         create_hook_ticket,
         hook_events,
         create_webhook,
@@ -136,6 +140,8 @@ pub async fn app(config: &Figment) -> Result<Rocket<Build>> {
         tinycloud_config.hooks.clone(),
         key_setup.derive_key(b"tinycloud/hooks/tickets"),
     );
+    let signed_url_runtime =
+        signed_urls::SignedUrlRuntime::new(key_setup.derive_key(b"tinycloud/kv/signed-urls"));
 
     // Initialize TEE context if running in dstack mode
     let tee_context: Option<TeeContext> = {
@@ -241,6 +247,7 @@ pub async fn app(config: &Figment) -> Result<Rocket<Build>> {
         .manage(duckdb_service)
         .manage(quota_cache)
         .manage(hook_runtime)
+        .manage(signed_url_runtime)
         .manage(webhook_encryption)
         .manage(rate_limiter)
         .manage(tee_context)

--- a/tinycloud-node-server/src/routes/mod.rs
+++ b/tinycloud-node-server/src/routes/mod.rs
@@ -13,10 +13,10 @@ use crate::{
     config::Config,
     hooks::{HookRuntime, WriteEvent},
     quota::QuotaCache,
-    routes::public::{is_public_space, RawKeyPath},
+    routes::public::is_public_space,
     signed_urls::{
-        mint_signed_kv_url, validate_signed_kv_url, SignedKvUrlRequest, SignedKvUrlResponse,
-        SignedUrlRuntime,
+        load_signed_kv_ticket, mint_signed_kv_url, validate_signed_kv_hash_binding,
+        validate_signed_kv_ticket, SignedKvUrlRequest, SignedKvUrlResponse, SignedUrlRuntime,
     },
     tracing::TracingSpan,
     BlockStage, BlockStores, TinyCloud,
@@ -138,6 +138,7 @@ pub async fn create_signed_kv_url(
     tinycloud: &State<TinyCloud>,
 ) -> Result<Json<SignedKvUrlResponse>, (Status, String)> {
     let invocation_info = invocation.0 .0.clone();
+    verify_auth(invocation.0, tinycloud).await?;
     let response = mint_signed_kv_url(
         &invocation_info,
         request.into_inner(),
@@ -145,37 +146,29 @@ pub async fn create_signed_kv_url(
         tinycloud.inner(),
     )
     .await?;
-    verify_auth(invocation.0, tinycloud).await?;
     Ok(Json(response))
 }
 
-#[get("/signed/kv/<space_id>/<key..>?<token>")]
+#[get("/signed/kv/<ticket_id>")]
 pub async fn signed_kv_get(
-    space_id: &str,
-    key: RawKeyPath,
-    token: &str,
-    runtime: &State<SignedUrlRuntime>,
+    ticket_id: &str,
     tinycloud: &State<TinyCloud>,
 ) -> Result<
     KVResponse<tinycloud_core::storage::Content<<BlockStores as ImmutableReadStore>::Readable>>,
     (Status, String),
 > {
-    let space_id: tinycloud_auth::resource::SpaceId = space_id
-        .parse()
-        .map_err(|_| (Status::BadRequest, "Invalid space ID".to_string()))?;
-    let key: tinycloud_auth::resource::Path = key
-        .0
-        .parse()
-        .map_err(|_| (Status::BadRequest, "Invalid key".to_string()))?;
-
-    validate_signed_kv_url(runtime.inner(), token, &space_id, &key)?;
+    let ticket = load_signed_kv_ticket(tinycloud.inner(), ticket_id).await?;
+    let (space_id, key) = validate_signed_kv_ticket(&ticket)?;
 
     match tinycloud
-        .public_kv_get(&space_id, &key)
+        .kv_get(&space_id, &key)
         .await
         .map_err(|e| (Status::InternalServerError, e.to_string()))?
     {
-        Some((md, hash, content)) => Ok(KVResponse::new(md, hash, content)),
+        Some((md, hash, content)) => {
+            validate_signed_kv_hash_binding(&ticket, &hash)?;
+            Ok(KVResponse::new(md, hash, content))
+        }
         None => Err((Status::NotFound, "Key not found".to_string())),
     }
 }

--- a/tinycloud-node-server/src/routes/mod.rs
+++ b/tinycloud-node-server/src/routes/mod.rs
@@ -8,12 +8,16 @@ use tokio_util::compat::TokioAsyncReadCompatExt;
 use tracing::{info_span, Instrument};
 
 use crate::{
-    auth_guards::{DataIn, DataOut, InvOut, ObjectHeaders},
+    auth_guards::{DataIn, DataOut, InvOut, KVResponse, ObjectHeaders},
     authorization::AuthHeaderGetter,
     config::Config,
     hooks::{HookRuntime, WriteEvent},
     quota::QuotaCache,
-    routes::public::is_public_space,
+    routes::public::{is_public_space, RawKeyPath},
+    signed_urls::{
+        mint_signed_kv_url, validate_signed_kv_url, SignedKvUrlRequest, SignedKvUrlResponse,
+        SignedUrlRuntime,
+    },
     tracing::TracingSpan,
     BlockStage, BlockStores, TinyCloud,
 };
@@ -54,7 +58,15 @@ fn build_info(
     quota_cache: &State<QuotaCache>,
 ) -> NodeInfo {
     #[allow(unused_mut)]
-    let mut features = vec!["kv", "delegation", "sharing", "sql", "duckdb", "hooks"];
+    let mut features = vec![
+        "kv",
+        "delegation",
+        "sharing",
+        "sql",
+        "duckdb",
+        "hooks",
+        "signed-urls",
+    ];
     #[cfg(feature = "dstack")]
     features.push("tee");
     NodeInfo {
@@ -116,6 +128,56 @@ pub async fn open_host_key(
             "Failed to stage keypair for space",
         )
     })
+}
+
+#[post("/signed/kv", format = "json", data = "<request>")]
+pub async fn create_signed_kv_url(
+    invocation: AuthHeaderGetter<InvocationInfo>,
+    request: Json<SignedKvUrlRequest>,
+    runtime: &State<SignedUrlRuntime>,
+    tinycloud: &State<TinyCloud>,
+) -> Result<Json<SignedKvUrlResponse>, (Status, String)> {
+    let invocation_info = invocation.0 .0.clone();
+    let response = mint_signed_kv_url(
+        &invocation_info,
+        request.into_inner(),
+        runtime.inner(),
+        tinycloud.inner(),
+    )
+    .await?;
+    verify_auth(invocation.0, tinycloud).await?;
+    Ok(Json(response))
+}
+
+#[get("/signed/kv/<space_id>/<key..>?<token>")]
+pub async fn signed_kv_get(
+    space_id: &str,
+    key: RawKeyPath,
+    token: &str,
+    runtime: &State<SignedUrlRuntime>,
+    tinycloud: &State<TinyCloud>,
+) -> Result<
+    KVResponse<tinycloud_core::storage::Content<<BlockStores as ImmutableReadStore>::Readable>>,
+    (Status, String),
+> {
+    let space_id: tinycloud_auth::resource::SpaceId = space_id
+        .parse()
+        .map_err(|_| (Status::BadRequest, "Invalid space ID".to_string()))?;
+    let key: tinycloud_auth::resource::Path = key
+        .0
+        .parse()
+        .map_err(|_| (Status::BadRequest, "Invalid key".to_string()))?;
+
+    validate_signed_kv_url(runtime.inner(), token, &space_id, &key)?;
+
+    match tinycloud
+        .public_kv_get(&space_id, &key)
+        .await
+        .map_err(|e| (Status::InternalServerError, e.to_string()))?
+    {
+        Some((md, hash, content)) => Ok(KVResponse::new(md, hash, content)),
+        None => Err((Status::NotFound, "Key not found".to_string())),
+    }
 }
 
 #[derive(Serialize)]

--- a/tinycloud-node-server/src/signed_urls.rs
+++ b/tinycloud-node-server/src/signed_urls.rs
@@ -1,0 +1,453 @@
+use crate::TinyCloud;
+use base64::{decode_config, encode_config, URL_SAFE_NO_PAD};
+use hmac::{Hmac, Mac};
+use rocket::http::Status;
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+use tinycloud_auth::resource::{Path, SpaceId};
+use tinycloud_core::{
+    hash::Hash,
+    models::delegation,
+    sea_orm::{ColumnTrait, EntityTrait, QueryFilter},
+    types::Resource,
+    util::InvocationInfo,
+};
+
+type SignedUrlMac = Hmac<Sha256>;
+
+#[derive(Debug)]
+pub struct SignedUrlRuntime {
+    signing_key: [u8; 32],
+    max_ttl_seconds: u64,
+}
+
+impl SignedUrlRuntime {
+    pub fn new(signing_key: [u8; 32]) -> Self {
+        Self {
+            signing_key,
+            max_ttl_seconds: 300,
+        }
+    }
+
+    pub fn max_ttl_seconds(&self) -> u64 {
+        self.max_ttl_seconds
+    }
+
+    pub fn sign(&self, claims: &SignedKvUrlClaims) -> Result<String, String> {
+        let payload = serde_json::to_vec(claims).map_err(|e| e.to_string())?;
+        let encoded_payload = encode_config(payload, URL_SAFE_NO_PAD);
+        let mut mac = SignedUrlMac::new_from_slice(&self.signing_key).map_err(|e| e.to_string())?;
+        mac.update(encoded_payload.as_bytes());
+        let signature = mac.finalize().into_bytes();
+        let encoded_signature = encode_config(signature, URL_SAFE_NO_PAD);
+        Ok(format!("{encoded_payload}.{encoded_signature}"))
+    }
+
+    pub fn verify(&self, token: &str) -> Result<SignedKvUrlClaims, String> {
+        let (encoded_payload, encoded_signature) = token
+            .split_once('.')
+            .ok_or_else(|| "invalid signed URL token format".to_string())?;
+
+        let mut mac = SignedUrlMac::new_from_slice(&self.signing_key).map_err(|e| e.to_string())?;
+        mac.update(encoded_payload.as_bytes());
+        let signature = decode_config(encoded_signature, URL_SAFE_NO_PAD)
+            .map_err(|_| "invalid signed URL token signature".to_string())?;
+        mac.verify_slice(&signature)
+            .map_err(|_| "invalid signed URL token signature".to_string())?;
+
+        let payload = decode_config(encoded_payload, URL_SAFE_NO_PAD)
+            .map_err(|_| "invalid signed URL token payload".to_string())?;
+        serde_json::from_slice(&payload).map_err(|_| "invalid signed URL token payload".to_string())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SignedKvUrlRequest {
+    pub space: String,
+    pub path: String,
+    #[serde(default)]
+    pub ttl_seconds: Option<u64>,
+    #[serde(default)]
+    pub max_uses: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SignedKvUrlResponse {
+    pub url: String,
+    pub token: String,
+    pub expires_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SignedKvUrlClaims {
+    pub v: u8,
+    pub sub: String,
+    pub space: String,
+    pub path: String,
+    pub iat: i64,
+    pub exp: i64,
+    pub parent_exp: i64,
+}
+
+pub async fn mint_signed_kv_url(
+    invocation: &InvocationInfo,
+    request: SignedKvUrlRequest,
+    runtime: &SignedUrlRuntime,
+    tinycloud: &TinyCloud,
+) -> Result<SignedKvUrlResponse, (Status, String)> {
+    if request.max_uses.is_some() {
+        return Err((
+            Status::BadRequest,
+            "maxUses is not supported for signed KV URLs yet".to_string(),
+        ));
+    }
+
+    let space: SpaceId = request
+        .space
+        .parse()
+        .map_err(|_| (Status::BadRequest, "Invalid space ID".to_string()))?;
+    let path: Path = request
+        .path
+        .parse()
+        .map_err(|_| (Status::BadRequest, "Invalid path".to_string()))?;
+
+    if !has_only_exact_kv_get(invocation, &space, &path) {
+        return Err((
+            Status::Forbidden,
+            "signed URL scope is not authorized".to_string(),
+        ));
+    }
+
+    let now = OffsetDateTime::now_utc();
+    let invocation_exp = invocation_expiry(invocation);
+    let parent_exp = find_parent_expiry(invocation, tinycloud)
+        .await?
+        .unwrap_or(invocation_exp);
+    let requested_ttl = request
+        .ttl_seconds
+        .unwrap_or(runtime.max_ttl_seconds())
+        .min(runtime.max_ttl_seconds()) as i64;
+    let exp = (now.unix_timestamp() + requested_ttl)
+        .min(invocation_exp)
+        .min(parent_exp);
+
+    if exp <= now.unix_timestamp() {
+        return Err((
+            Status::Unauthorized,
+            "signed URL expired immediately".to_string(),
+        ));
+    }
+
+    let claims = SignedKvUrlClaims {
+        v: 1,
+        sub: invocation.invoker.clone(),
+        space: space.to_string(),
+        path: path.to_string(),
+        iat: now.unix_timestamp(),
+        exp,
+        parent_exp,
+    };
+    let token = runtime
+        .sign(&claims)
+        .map_err(|e| (Status::InternalServerError, e))?;
+    let expires_at = OffsetDateTime::from_unix_timestamp(exp)
+        .map_err(|e| (Status::InternalServerError, e.to_string()))?
+        .format(&Rfc3339)
+        .map_err(|e| (Status::InternalServerError, e.to_string()))?;
+    let url = format!("/signed/kv/{}/{}?token={}", space, path, token);
+
+    Ok(SignedKvUrlResponse {
+        url,
+        token,
+        expires_at,
+    })
+}
+
+pub fn validate_signed_kv_url(
+    runtime: &SignedUrlRuntime,
+    token: &str,
+    space: &SpaceId,
+    path: &Path,
+) -> Result<SignedKvUrlClaims, (Status, String)> {
+    let claims = runtime
+        .verify(token)
+        .map_err(|e| (Status::Unauthorized, e))?;
+    let now = OffsetDateTime::now_utc().unix_timestamp();
+
+    if claims.exp <= now || claims.parent_exp <= now {
+        return Err((Status::Unauthorized, "signed URL expired".to_string()));
+    }
+    if claims.space != space.to_string() || claims.path != path.to_string() {
+        return Err((
+            Status::Forbidden,
+            "signed URL scope does not match request".to_string(),
+        ));
+    }
+
+    Ok(claims)
+}
+
+pub fn has_only_exact_kv_get(invocation: &InvocationInfo, space: &SpaceId, path: &Path) -> bool {
+    !invocation.capabilities.is_empty()
+        && invocation
+            .capabilities
+            .iter()
+            .all(|capability| matches_exact_kv_get(capability, space, path))
+}
+
+fn matches_exact_kv_get(
+    capability: &tinycloud_core::util::Capability,
+    space: &SpaceId,
+    path: &Path,
+) -> bool {
+    match (&capability.resource, capability.ability.as_ref().as_ref()) {
+        (Resource::TinyCloud(resource), "tinycloud.kv/get") => {
+            resource.service().as_str() == "kv"
+                && resource.space() == space
+                && resource.path().is_some_and(|p| p == path)
+        }
+        _ => false,
+    }
+}
+
+fn invocation_expiry(invocation: &InvocationInfo) -> i64 {
+    invocation
+        .invocation
+        .payload()
+        .expiration
+        .as_seconds()
+        .floor() as i64
+}
+
+async fn find_parent_expiry(
+    invocation: &InvocationInfo,
+    tinycloud: &TinyCloud,
+) -> Result<Option<i64>, (Status, String)> {
+    if invocation.parents.is_empty() {
+        return Ok(None);
+    }
+
+    let tx = tinycloud
+        .readable()
+        .await
+        .map_err(|e| (Status::InternalServerError, e.to_string()))?;
+    let parent_ids: Vec<Hash> = invocation
+        .parents
+        .iter()
+        .map(|cid| Hash::from(*cid))
+        .collect();
+    let expiries = delegation::Entity::find()
+        .filter(delegation::Column::Id.is_in(parent_ids))
+        .all(&tx)
+        .await
+        .map_err(|e| (Status::InternalServerError, e.to_string()))?;
+
+    Ok(expiries
+        .into_iter()
+        .filter_map(|delegation| delegation.expiry.map(|expiry| expiry.unix_timestamp()))
+        .min())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+    use tempfile::TempDir;
+    use tinycloud_auth::{
+        authorization::{make_invocation, InvocationOptions},
+        ipld_core::cid::Cid,
+        multihash_codetable::{Code, MultihashDigest},
+        resolver::DID_METHODS,
+        resource::{ResourceId, Service},
+        siwe_recap::Ability,
+        ssi::{dids::DIDBuf, jwk::JWK},
+    };
+    use tinycloud_core::{
+        keys::StaticSecret,
+        sea_orm::{ConnectOptions, Database},
+        storage::either::Either,
+        storage::StorageConfig as _,
+        util::InvocationInfo as CoreInvocationInfo,
+    };
+
+    use crate::storage::file_system::FileSystemConfig as NodeFileSystemConfig;
+
+    async fn test_tinycloud() -> Result<TinyCloud> {
+        let tempdir = TempDir::new()?;
+        let db = Database::connect(ConnectOptions::new("sqlite::memory:".to_string())).await?;
+        let storage = NodeFileSystemConfig::new(tempdir.path()).open().await?;
+        let _persisted = tempdir.keep();
+        Ok(TinyCloud::new(
+            db,
+            Either::B(storage),
+            StaticSecret::new(vec![0u8; 32]).unwrap(),
+        )
+        .await?)
+    }
+
+    fn test_invocation(kv_path: &str) -> Result<(CoreInvocationInfo, SpaceId)> {
+        let jwk = JWK::generate_ed25519()?;
+        let mut verification_method = DID_METHODS.generate(&jwk, "key")?.to_string();
+        let fragment = verification_method
+            .rsplit_once(':')
+            .ok_or_else(|| anyhow::anyhow!("missing verification method fragment"))?
+            .1
+            .to_string();
+        verification_method.push('#');
+        verification_method.push_str(&fragment);
+
+        let did: DIDBuf = verification_method
+            .split('#')
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("missing did"))?
+            .parse()?;
+        let space = SpaceId::new(did, "alpha".parse()?);
+        let resource: ResourceId = space.clone().to_resource(
+            "kv".parse::<Service>()?,
+            Some(kv_path.parse::<Path>()?),
+            None,
+            None,
+        );
+
+        let delegation = Cid::new_v1(0x55, Code::Blake3_256.digest(b"delegation"));
+        let invocation = make_invocation(
+            vec![(resource, vec!["tinycloud.kv/get".parse::<Ability>()?])],
+            &delegation,
+            &jwk,
+            &verification_method,
+            4_102_444_800.0,
+            InvocationOptions::default(),
+        )?;
+
+        Ok((CoreInvocationInfo::try_from(invocation)?, space))
+    }
+
+    #[tokio::test]
+    async fn signed_kv_url_token_round_trips() {
+        let runtime = SignedUrlRuntime::new([7u8; 32]);
+        let claims = SignedKvUrlClaims {
+            v: 1,
+            sub: "did:key:test".to_string(),
+            space: "tinycloud:space".to_string(),
+            path: "documents/audio.wav".to_string(),
+            iat: 10,
+            exp: 20,
+            parent_exp: 20,
+        };
+
+        let token = runtime.sign(&claims).unwrap();
+        let decoded = runtime.verify(&token).unwrap();
+        assert_eq!(decoded, claims);
+    }
+
+    #[tokio::test]
+    async fn signed_kv_url_rejects_wrong_path_scope() -> Result<()> {
+        let runtime = SignedUrlRuntime::new([7u8; 32]);
+        let (invocation, space) = test_invocation("documents/audio.wav")?;
+        let claims = SignedKvUrlClaims {
+            v: 1,
+            sub: invocation.invoker,
+            space: space.to_string(),
+            path: "documents/audio.wav".to_string(),
+            iat: 10,
+            exp: 4_102_444_800,
+            parent_exp: 4_102_444_800,
+        };
+        let token = runtime.sign(&claims).unwrap();
+        let wrong_path = "documents/other.wav".parse::<Path>()?;
+
+        let err = validate_signed_kv_url(&runtime, &token, &space, &wrong_path)
+            .expect_err("wrong path should be rejected");
+        assert_eq!(err.0, Status::Forbidden);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn signed_kv_url_rejects_expired_token() -> Result<()> {
+        let runtime = SignedUrlRuntime::new([7u8; 32]);
+        let (_invocation, space) = test_invocation("documents/audio.wav")?;
+        let path = "documents/audio.wav".parse::<Path>()?;
+        let claims = SignedKvUrlClaims {
+            v: 1,
+            sub: "did:key:test".to_string(),
+            space: space.to_string(),
+            path: path.to_string(),
+            iat: 10,
+            exp: 20,
+            parent_exp: 20,
+        };
+        let token = runtime.sign(&claims).unwrap();
+
+        let err = validate_signed_kv_url(&runtime, &token, &space, &path)
+            .expect_err("expired token should be rejected");
+        assert_eq!(err.0, Status::Unauthorized);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn mints_signed_kv_url_for_authorized_exact_scope() -> Result<()> {
+        let tinycloud = test_tinycloud().await?;
+        let runtime = SignedUrlRuntime::new([7u8; 32]);
+        let (invocation, space) = test_invocation("documents/audio.wav")?;
+        let response = mint_signed_kv_url(
+            &invocation,
+            SignedKvUrlRequest {
+                space: space.to_string(),
+                path: "documents/audio.wav".to_string(),
+                ttl_seconds: Some(60),
+                max_uses: None,
+            },
+            &runtime,
+            &tinycloud,
+        )
+        .await
+        .expect("signed URL");
+
+        let path = "documents/audio.wav".parse::<Path>()?;
+        let claims = validate_signed_kv_url(&runtime, &response.token, &space, &path)
+            .expect("minted URL should validate");
+        assert_eq!(claims.space, space.to_string());
+        assert_eq!(claims.path, "documents/audio.wav");
+        assert!(response.url.starts_with("/signed/kv/"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rejects_max_uses_without_durable_state() -> Result<()> {
+        let tinycloud = test_tinycloud().await?;
+        let runtime = SignedUrlRuntime::new([7u8; 32]);
+        let (invocation, space) = test_invocation("documents/audio.wav")?;
+
+        let err = mint_signed_kv_url(
+            &invocation,
+            SignedKvUrlRequest {
+                space: space.to_string(),
+                path: "documents/audio.wav".to_string(),
+                ttl_seconds: Some(60),
+                max_uses: Some(1),
+            },
+            &runtime,
+            &tinycloud,
+        )
+        .await
+        .expect_err("maxUses should be rejected");
+
+        assert_eq!(err.0, Status::BadRequest);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn authorization_requires_exact_kv_get_scope() -> Result<()> {
+        let (invocation, space) = test_invocation("documents/audio.wav")?;
+        let authorized_path = "documents/audio.wav".parse::<Path>()?;
+        let wrong_path = "documents/other.wav".parse::<Path>()?;
+
+        assert!(has_only_exact_kv_get(&invocation, &space, &authorized_path));
+        assert!(!has_only_exact_kv_get(&invocation, &space, &wrong_path));
+        Ok(())
+    }
+}

--- a/tinycloud-node-server/src/signed_urls.rs
+++ b/tinycloud-node-server/src/signed_urls.rs
@@ -1,20 +1,24 @@
 use crate::TinyCloud;
-use base64::{decode_config, encode_config, URL_SAFE_NO_PAD};
+use base64::{encode_config, URL_SAFE_NO_PAD};
 use hmac::{Hmac, Mac};
+use rand::{rngs::OsRng, RngCore};
 use rocket::http::Status;
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
-use tinycloud_auth::resource::{Path, SpaceId};
+use tinycloud_auth::resource::{Path, Service, SpaceId};
 use tinycloud_core::{
     hash::Hash,
-    models::delegation,
+    models::{delegation, signed_kv_ticket},
     sea_orm::{ColumnTrait, EntityTrait, QueryFilter},
     types::Resource,
     util::InvocationInfo,
 };
 
-type SignedUrlMac = Hmac<Sha256>;
+type TicketIdMac = Hmac<Sha256>;
+
+const SIGNED_KV_SERVICE: &str = "kv";
+const SIGNED_KV_ABILITY: &str = "tinycloud.kv/get";
 
 #[derive(Debug)]
 pub struct SignedUrlRuntime {
@@ -34,31 +38,12 @@ impl SignedUrlRuntime {
         self.max_ttl_seconds
     }
 
-    pub fn sign(&self, claims: &SignedKvUrlClaims) -> Result<String, String> {
-        let payload = serde_json::to_vec(claims).map_err(|e| e.to_string())?;
-        let encoded_payload = encode_config(payload, URL_SAFE_NO_PAD);
-        let mut mac = SignedUrlMac::new_from_slice(&self.signing_key).map_err(|e| e.to_string())?;
-        mac.update(encoded_payload.as_bytes());
-        let signature = mac.finalize().into_bytes();
-        let encoded_signature = encode_config(signature, URL_SAFE_NO_PAD);
-        Ok(format!("{encoded_payload}.{encoded_signature}"))
-    }
-
-    pub fn verify(&self, token: &str) -> Result<SignedKvUrlClaims, String> {
-        let (encoded_payload, encoded_signature) = token
-            .split_once('.')
-            .ok_or_else(|| "invalid signed URL token format".to_string())?;
-
-        let mut mac = SignedUrlMac::new_from_slice(&self.signing_key).map_err(|e| e.to_string())?;
-        mac.update(encoded_payload.as_bytes());
-        let signature = decode_config(encoded_signature, URL_SAFE_NO_PAD)
-            .map_err(|_| "invalid signed URL token signature".to_string())?;
-        mac.verify_slice(&signature)
-            .map_err(|_| "invalid signed URL token signature".to_string())?;
-
-        let payload = decode_config(encoded_payload, URL_SAFE_NO_PAD)
-            .map_err(|_| "invalid signed URL token payload".to_string())?;
-        serde_json::from_slice(&payload).map_err(|_| "invalid signed URL token payload".to_string())
+    pub fn ticket_id(&self) -> Result<String, String> {
+        let mut nonce = [0u8; 32];
+        OsRng.fill_bytes(&mut nonce);
+        let mut mac = TicketIdMac::new_from_slice(&self.signing_key).map_err(|e| e.to_string())?;
+        mac.update(&nonce);
+        Ok(encode_config(mac.finalize().into_bytes(), URL_SAFE_NO_PAD))
     }
 }
 
@@ -71,26 +56,18 @@ pub struct SignedKvUrlRequest {
     pub ttl_seconds: Option<u64>,
     #[serde(default)]
     pub max_uses: Option<u64>,
+    #[serde(default)]
+    pub content_hash: Option<String>,
+    #[serde(default)]
+    pub etag: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SignedKvUrlResponse {
     pub url: String,
-    pub token: String,
+    pub ticket_id: String,
     pub expires_at: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct SignedKvUrlClaims {
-    pub v: u8,
-    pub sub: String,
-    pub space: String,
-    pub path: String,
-    pub iat: i64,
-    pub exp: i64,
-    pub parent_exp: i64,
 }
 
 pub async fn mint_signed_kv_url(
@@ -115,7 +92,7 @@ pub async fn mint_signed_kv_url(
         .parse()
         .map_err(|_| (Status::BadRequest, "Invalid path".to_string()))?;
 
-    if !has_only_exact_kv_get(invocation, &space, &path) {
+    if !has_attenuable_kv_get(invocation, &space, &path)? {
         return Err((
             Status::Forbidden,
             "signed URL scope is not authorized".to_string(),
@@ -124,9 +101,8 @@ pub async fn mint_signed_kv_url(
 
     let now = OffsetDateTime::now_utc();
     let invocation_exp = invocation_expiry(invocation);
-    let parent_exp = find_parent_expiry(invocation, tinycloud)
-        .await?
-        .unwrap_or(invocation_exp);
+    let parent_expiry = find_parent_expiry(invocation, tinycloud).await?;
+    let parent_exp = parent_expiry.unwrap_or(invocation_exp);
     let requested_ttl = request
         .ttl_seconds
         .unwrap_or(runtime.max_ttl_seconds())
@@ -142,76 +118,205 @@ pub async fn mint_signed_kv_url(
         ));
     }
 
-    let claims = SignedKvUrlClaims {
-        v: 1,
-        sub: invocation.invoker.clone(),
-        space: space.to_string(),
-        path: path.to_string(),
-        iat: now.unix_timestamp(),
-        exp,
-        parent_exp,
-    };
-    let token = runtime
-        .sign(&claims)
+    let ticket_id = runtime
+        .ticket_id()
         .map_err(|e| (Status::InternalServerError, e))?;
-    let expires_at = OffsetDateTime::from_unix_timestamp(exp)
-        .map_err(|e| (Status::InternalServerError, e.to_string()))?
-        .format(&Rfc3339)
+    let created_at = format_timestamp(now)?;
+    let expires_at = format_timestamp(unix_timestamp(exp)?)?;
+    let invocation_expires_at = Some(format_timestamp(unix_timestamp(invocation_exp)?)?);
+    let parent_expires_at = parent_expiry
+        .map(|expiry| unix_timestamp(expiry).and_then(format_timestamp))
+        .transpose()?;
+    let content_hash = request
+        .content_hash
+        .as_deref()
+        .map(normalize_content_hash)
+        .transpose()?;
+    let etag = request.etag.map(|etag| etag.trim().to_string());
+    let parent_cids_json = if invocation.parents.is_empty() {
+        None
+    } else {
+        Some(
+            serde_json::to_string(
+                &invocation
+                    .parents
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>(),
+            )
+            .map_err(|e| (Status::InternalServerError, e.to_string()))?,
+        )
+    };
+
+    let ticket = signed_kv_ticket::Model {
+        id: ticket_id.clone(),
+        issuer_did: invocation.invoker.clone(),
+        subject_did: invocation.invoker.clone(),
+        space_id: space.to_string(),
+        path: path.to_string(),
+        service: SIGNED_KV_SERVICE.to_string(),
+        ability: SIGNED_KV_ABILITY.to_string(),
+        created_at,
+        expires_at: expires_at.clone(),
+        invocation_expires_at,
+        parent_expires_at,
+        content_hash,
+        etag,
+        parent_cids_json,
+    };
+    tinycloud
+        .create_signed_kv_ticket(ticket)
+        .await
         .map_err(|e| (Status::InternalServerError, e.to_string()))?;
-    let url = format!("/signed/kv/{}/{}?token={}", space, path, token);
+    let url = format!("/signed/kv/{ticket_id}");
 
     Ok(SignedKvUrlResponse {
         url,
-        token,
+        ticket_id,
         expires_at,
     })
 }
 
-pub fn validate_signed_kv_url(
-    runtime: &SignedUrlRuntime,
-    token: &str,
-    space: &SpaceId,
-    path: &Path,
-) -> Result<SignedKvUrlClaims, (Status, String)> {
-    let claims = runtime
-        .verify(token)
-        .map_err(|e| (Status::Unauthorized, e))?;
-    let now = OffsetDateTime::now_utc().unix_timestamp();
+pub async fn load_signed_kv_ticket(
+    tinycloud: &TinyCloud,
+    ticket_id: &str,
+) -> Result<signed_kv_ticket::Model, (Status, String)> {
+    let ticket = tinycloud
+        .find_signed_kv_ticket(ticket_id)
+        .await
+        .map_err(|e| (Status::InternalServerError, e.to_string()))?
+        .ok_or_else(|| {
+            (
+                Status::Unauthorized,
+                "signed URL ticket not found".to_string(),
+            )
+        })?;
+    validate_signed_kv_ticket(&ticket)?;
+    Ok(ticket)
+}
 
-    if claims.exp <= now || claims.parent_exp <= now {
-        return Err((Status::Unauthorized, "signed URL expired".to_string()));
-    }
-    if claims.space != space.to_string() || claims.path != path.to_string() {
+pub fn validate_signed_kv_ticket(
+    ticket: &signed_kv_ticket::Model,
+) -> Result<(SpaceId, Path), (Status, String)> {
+    if ticket.service != SIGNED_KV_SERVICE || ticket.ability != SIGNED_KV_ABILITY {
         return Err((
             Status::Forbidden,
-            "signed URL scope does not match request".to_string(),
+            "signed URL ticket has invalid scope".to_string(),
         ));
     }
 
-    Ok(claims)
+    let expires_at = OffsetDateTime::parse(&ticket.expires_at, &Rfc3339).map_err(|_| {
+        (
+            Status::Unauthorized,
+            "signed URL ticket is invalid".to_string(),
+        )
+    })?;
+    if expires_at <= OffsetDateTime::now_utc() {
+        return Err((Status::Unauthorized, "signed URL expired".to_string()));
+    }
+
+    let space = ticket.space_id.parse().map_err(|_| {
+        (
+            Status::Unauthorized,
+            "signed URL ticket is invalid".to_string(),
+        )
+    })?;
+    let path = ticket.path.parse().map_err(|_| {
+        (
+            Status::Unauthorized,
+            "signed URL ticket is invalid".to_string(),
+        )
+    })?;
+    Ok((space, path))
 }
 
-pub fn has_only_exact_kv_get(invocation: &InvocationInfo, space: &SpaceId, path: &Path) -> bool {
-    !invocation.capabilities.is_empty()
-        && invocation
-            .capabilities
-            .iter()
-            .all(|capability| matches_exact_kv_get(capability, space, path))
+pub fn validate_signed_kv_hash_binding(
+    ticket: &signed_kv_ticket::Model,
+    hash: &Hash,
+) -> Result<(), (Status, String)> {
+    let current_hash = hex::encode(hash.as_ref());
+
+    if let Some(bound_hash) = &ticket.content_hash {
+        let bound_hash = normalize_content_hash(bound_hash)?;
+        if bound_hash != current_hash {
+            return Err((
+                Status::PreconditionFailed,
+                "signed URL content hash does not match".to_string(),
+            ));
+        }
+    }
+
+    if let Some(bound_etag) = &ticket.etag {
+        let current_etag = format!("\"blake3-{current_hash}\"");
+        if bound_etag.trim() != current_etag {
+            return Err((
+                Status::PreconditionFailed,
+                "signed URL ETag does not match".to_string(),
+            ));
+        }
+    }
+
+    Ok(())
 }
 
-fn matches_exact_kv_get(
-    capability: &tinycloud_core::util::Capability,
+pub fn has_attenuable_kv_get(
+    invocation: &InvocationInfo,
     space: &SpaceId,
     path: &Path,
+) -> Result<bool, (Status, String)> {
+    let requested = requested_kv_resource(space, path)?;
+    Ok(invocation
+        .capabilities
+        .iter()
+        .any(|capability| matches_attenuable_kv_get(capability, &requested)))
+}
+
+fn matches_attenuable_kv_get(
+    capability: &tinycloud_core::util::Capability,
+    requested: &Resource,
 ) -> bool {
-    match (&capability.resource, capability.ability.as_ref().as_ref()) {
-        (Resource::TinyCloud(resource), "tinycloud.kv/get") => {
-            resource.service().as_str() == "kv"
-                && resource.space() == space
-                && resource.path().is_some_and(|p| p == path)
-        }
-        _ => false,
+    capability.ability.as_ref().as_ref() == SIGNED_KV_ABILITY
+        && requested.extends(&capability.resource)
+}
+
+fn requested_kv_resource(space: &SpaceId, path: &Path) -> Result<Resource, (Status, String)> {
+    Ok(Resource::TinyCloud(
+        space.clone().to_resource(
+            SIGNED_KV_SERVICE
+                .parse::<Service>()
+                .map_err(|_| (Status::InternalServerError, "Invalid service".to_string()))?,
+            Some(path.clone()),
+            None,
+            None,
+        ),
+    ))
+}
+
+fn normalize_content_hash(value: &str) -> Result<String, (Status, String)> {
+    let normalized = value
+        .trim()
+        .trim_matches('"')
+        .strip_prefix("blake3-")
+        .unwrap_or_else(|| value.trim().trim_matches('"'))
+        .to_ascii_lowercase();
+    if normalized.len() != 64 || !normalized.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err((
+            Status::BadRequest,
+            "contentHash must be a blake3 hex digest".to_string(),
+        ));
     }
+    Ok(normalized)
+}
+
+fn unix_timestamp(timestamp: i64) -> Result<OffsetDateTime, (Status, String)> {
+    OffsetDateTime::from_unix_timestamp(timestamp)
+        .map_err(|e| (Status::InternalServerError, e.to_string()))
+}
+
+fn format_timestamp(timestamp: OffsetDateTime) -> Result<String, (Status, String)> {
+    timestamp
+        .format(&Rfc3339)
+        .map_err(|e| (Status::InternalServerError, e.to_string()))
 }
 
 fn invocation_expiry(invocation: &InvocationInfo) -> i64 {
@@ -267,7 +372,9 @@ mod tests {
         ssi::{dids::DIDBuf, jwk::JWK},
     };
     use tinycloud_core::{
+        hash::hash,
         keys::StaticSecret,
+        models::signed_kv_ticket,
         sea_orm::{ConnectOptions, Database},
         storage::either::Either,
         storage::StorageConfig as _,
@@ -326,64 +433,87 @@ mod tests {
         Ok((CoreInvocationInfo::try_from(invocation)?, space))
     }
 
-    #[tokio::test]
-    async fn signed_kv_url_token_round_trips() {
-        let runtime = SignedUrlRuntime::new([7u8; 32]);
-        let claims = SignedKvUrlClaims {
-            v: 1,
-            sub: "did:key:test".to_string(),
-            space: "tinycloud:space".to_string(),
-            path: "documents/audio.wav".to_string(),
-            iat: 10,
-            exp: 20,
-            parent_exp: 20,
-        };
+    fn test_invocation_with_caps(
+        caps: &[(&str, &str, &str)],
+    ) -> Result<(CoreInvocationInfo, SpaceId)> {
+        let jwk = JWK::generate_ed25519()?;
+        let mut verification_method = DID_METHODS.generate(&jwk, "key")?.to_string();
+        let fragment = verification_method
+            .rsplit_once(':')
+            .ok_or_else(|| anyhow::anyhow!("missing verification method fragment"))?
+            .1
+            .to_string();
+        verification_method.push('#');
+        verification_method.push_str(&fragment);
 
-        let token = runtime.sign(&claims).unwrap();
-        let decoded = runtime.verify(&token).unwrap();
-        assert_eq!(decoded, claims);
+        let did: DIDBuf = verification_method
+            .split('#')
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("missing did"))?
+            .parse()?;
+        let space = SpaceId::new(did, "alpha".parse()?);
+        let resources = caps
+            .iter()
+            .map(|(service, path, ability)| {
+                Ok((
+                    space.clone().to_resource(
+                        service.parse::<Service>()?,
+                        Some(path.parse::<Path>()?),
+                        None,
+                        None,
+                    ),
+                    vec![ability.parse::<Ability>()?],
+                ))
+            })
+            .collect::<Result<Vec<(ResourceId, Vec<Ability>)>>>()?;
+
+        let delegation = Cid::new_v1(0x55, Code::Blake3_256.digest(b"delegation"));
+        let invocation = make_invocation(
+            resources,
+            &delegation,
+            &jwk,
+            &verification_method,
+            4_102_444_800.0,
+            InvocationOptions::default(),
+        )?;
+
+        Ok((CoreInvocationInfo::try_from(invocation)?, space))
     }
 
-    #[tokio::test]
-    async fn signed_kv_url_rejects_wrong_path_scope() -> Result<()> {
-        let runtime = SignedUrlRuntime::new([7u8; 32]);
-        let (invocation, space) = test_invocation("documents/audio.wav")?;
-        let claims = SignedKvUrlClaims {
-            v: 1,
-            sub: invocation.invoker,
-            space: space.to_string(),
-            path: "documents/audio.wav".to_string(),
-            iat: 10,
-            exp: 4_102_444_800,
-            parent_exp: 4_102_444_800,
-        };
-        let token = runtime.sign(&claims).unwrap();
-        let wrong_path = "documents/other.wav".parse::<Path>()?;
-
-        let err = validate_signed_kv_url(&runtime, &token, &space, &wrong_path)
-            .expect_err("wrong path should be rejected");
-        assert_eq!(err.0, Status::Forbidden);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn signed_kv_url_rejects_expired_token() -> Result<()> {
-        let runtime = SignedUrlRuntime::new([7u8; 32]);
-        let (_invocation, space) = test_invocation("documents/audio.wav")?;
-        let path = "documents/audio.wav".parse::<Path>()?;
-        let claims = SignedKvUrlClaims {
-            v: 1,
-            sub: "did:key:test".to_string(),
-            space: space.to_string(),
+    fn ticket_model(
+        space: &SpaceId,
+        path: &str,
+        expires_at: OffsetDateTime,
+    ) -> signed_kv_ticket::Model {
+        signed_kv_ticket::Model {
+            id: "ticket-id".to_string(),
+            issuer_did: "did:key:test".to_string(),
+            subject_did: "did:key:test".to_string(),
+            space_id: space.to_string(),
             path: path.to_string(),
-            iat: 10,
-            exp: 20,
-            parent_exp: 20,
-        };
-        let token = runtime.sign(&claims).unwrap();
+            service: SIGNED_KV_SERVICE.to_string(),
+            ability: SIGNED_KV_ABILITY.to_string(),
+            created_at: format_timestamp(OffsetDateTime::now_utc()).unwrap(),
+            expires_at: format_timestamp(expires_at).unwrap(),
+            invocation_expires_at: None,
+            parent_expires_at: None,
+            content_hash: None,
+            etag: None,
+            parent_cids_json: None,
+        }
+    }
 
-        let err = validate_signed_kv_url(&runtime, &token, &space, &path)
-            .expect_err("expired token should be rejected");
+    #[tokio::test]
+    async fn signed_kv_ticket_rejects_expired_ticket() -> Result<()> {
+        let (_invocation, space) = test_invocation("documents/audio.wav")?;
+        let ticket = ticket_model(
+            &space,
+            "documents/audio.wav",
+            OffsetDateTime::now_utc() - time::Duration::seconds(1),
+        );
+
+        let err =
+            validate_signed_kv_ticket(&ticket).expect_err("expired ticket should be rejected");
         assert_eq!(err.0, Status::Unauthorized);
         Ok(())
     }
@@ -400,6 +530,8 @@ mod tests {
                 path: "documents/audio.wav".to_string(),
                 ttl_seconds: Some(60),
                 max_uses: None,
+                content_hash: None,
+                etag: None,
             },
             &runtime,
             &tinycloud,
@@ -407,12 +539,74 @@ mod tests {
         .await
         .expect("signed URL");
 
-        let path = "documents/audio.wav".parse::<Path>()?;
-        let claims = validate_signed_kv_url(&runtime, &response.token, &space, &path)
-            .expect("minted URL should validate");
-        assert_eq!(claims.space, space.to_string());
-        assert_eq!(claims.path, "documents/audio.wav");
-        assert!(response.url.starts_with("/signed/kv/"));
+        assert_eq!(response.url, format!("/signed/kv/{}", response.ticket_id));
+        assert!(!response.url.contains("?token="));
+        assert!(!response.url.contains(&space.to_string()));
+
+        let ticket = load_signed_kv_ticket(&tinycloud, &response.ticket_id)
+            .await
+            .expect("minted ticket should be persisted");
+        let (ticket_space, ticket_path) =
+            validate_signed_kv_ticket(&ticket).expect("persisted ticket should validate");
+        assert_eq!(ticket_space, space);
+        assert_eq!(ticket_path.as_str(), "documents/audio.wav");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn mints_signed_kv_url_for_broader_kv_get_among_other_caps() -> Result<()> {
+        let tinycloud = test_tinycloud().await?;
+        let runtime = SignedUrlRuntime::new([7u8; 32]);
+        let (invocation, space) = test_invocation_with_caps(&[
+            ("kv", "documents", "tinycloud.kv/get"),
+            ("sql", "main.db", "tinycloud.sql/read"),
+        ])?;
+        let response = mint_signed_kv_url(
+            &invocation,
+            SignedKvUrlRequest {
+                space: space.to_string(),
+                path: "documents/audio.wav".to_string(),
+                ttl_seconds: Some(60),
+                max_uses: None,
+                content_hash: None,
+                etag: None,
+            },
+            &runtime,
+            &tinycloud,
+        )
+        .await
+        .expect("broader kv/get capability should authorize ticket");
+
+        assert_eq!(response.url, format!("/signed/kv/{}", response.ticket_id));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rejects_unauthorized_path_scope() -> Result<()> {
+        let tinycloud = test_tinycloud().await?;
+        let runtime = SignedUrlRuntime::new([7u8; 32]);
+        let (invocation, space) = test_invocation_with_caps(&[
+            ("kv", "documents", "tinycloud.kv/get"),
+            ("kv", "other", "tinycloud.kv/put"),
+        ])?;
+
+        let err = mint_signed_kv_url(
+            &invocation,
+            SignedKvUrlRequest {
+                space: space.to_string(),
+                path: "documents2/audio.wav".to_string(),
+                ttl_seconds: Some(60),
+                max_uses: None,
+                content_hash: None,
+                etag: None,
+            },
+            &runtime,
+            &tinycloud,
+        )
+        .await
+        .expect_err("sibling path should not be authorized by prefix");
+
+        assert_eq!(err.0, Status::Forbidden);
         Ok(())
     }
 
@@ -429,6 +623,8 @@ mod tests {
                 path: "documents/audio.wav".to_string(),
                 ttl_seconds: Some(60),
                 max_uses: Some(1),
+                content_hash: None,
+                etag: None,
             },
             &runtime,
             &tinycloud,
@@ -441,13 +637,38 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn authorization_requires_exact_kv_get_scope() -> Result<()> {
-        let (invocation, space) = test_invocation("documents/audio.wav")?;
+    async fn authorization_allows_attenuable_kv_get_scope() -> Result<()> {
+        let (invocation, space) = test_invocation_with_caps(&[
+            ("kv", "documents", "tinycloud.kv/get"),
+            ("kv", "uploads", "tinycloud.kv/put"),
+        ])?;
         let authorized_path = "documents/audio.wav".parse::<Path>()?;
-        let wrong_path = "documents/other.wav".parse::<Path>()?;
+        let wrong_path = "documents2/audio.wav".parse::<Path>()?;
 
-        assert!(has_only_exact_kv_get(&invocation, &space, &authorized_path));
-        assert!(!has_only_exact_kv_get(&invocation, &space, &wrong_path));
+        assert!(has_attenuable_kv_get(&invocation, &space, &authorized_path)
+            .expect("valid requested resource"));
+        assert!(!has_attenuable_kv_get(&invocation, &space, &wrong_path)
+            .expect("valid requested resource"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn validates_optional_content_hash_binding() -> Result<()> {
+        let (_invocation, space) = test_invocation("documents/audio.wav")?;
+        let object_hash = hash(b"object bytes");
+        let mut ticket = ticket_model(
+            &space,
+            "documents/audio.wav",
+            OffsetDateTime::now_utc() + time::Duration::seconds(60),
+        );
+        ticket.content_hash = Some(hex::encode(object_hash.as_ref()));
+        validate_signed_kv_hash_binding(&ticket, &object_hash)
+            .expect("matching content hash should validate");
+
+        let other_hash = hash(b"other bytes");
+        let err = validate_signed_kv_hash_binding(&ticket, &other_hash)
+            .expect_err("mismatched content hash should be rejected");
+        assert_eq!(err.0, Status::PreconditionFailed);
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- Add signed KV URL creation via `POST /signed/kv` after normal invocation verification for an exact `tinycloud.kv/get` scope.
- Add signed KV fetch via `GET /signed/kv/<space>/<key..>?token=...`, scoped to the token space/path and bounded by token, invocation, and parent delegation expiry.
- Advertise `signed-urls` in node features and document the endpoint in README.

## Security / tradeoffs
- Creation accepts only exact KV get invocations for the requested object before running auth verification, so verification cannot execute write/delete capabilities as a side effect.
- Tokens are stateless HMAC-signed with a node-derived key and expire after at most 300 seconds.
- `maxUses` is explicitly rejected for now; correct limited-use URLs need durable server-side state to work across restarts and multi-node deployments.

## Tests
- `rustfmt --edition 2021 --check tinycloud-node-server/src/lib.rs tinycloud-node-server/src/routes/mod.rs tinycloud-node-server/src/signed_urls.rs`
- `cargo test -p tinycloud-node signed_urls -- --nocapture`
- `cargo test -p tinycloud-node`
- `cargo check -p tinycloud-node`