### PR TITLE
docs: document release-plz requirements

### DIFF
--- a/agent.changelog.md
+++ b/agent.changelog.md
@@ -8,3 +8,5 @@ Track changes to agent-facing development guidance for TinyCloud Node. Add a con
 - Added initial agent development notes covering project context, related repositories, build and
   testing expectations, debugging guidance, and additional repo-specific operating context. Tracked
   in TC-1389.
+- Added release-plz guidance requiring release-worthy changes to use conventional PR titles or merge
+  commits and to verify that generated release PR changelogs include the intended change.

--- a/agent.dev.md
+++ b/agent.dev.md
@@ -133,6 +133,10 @@ Server debugging:
 - Storage changes must preserve user data across deploys, restarts, and local cache loss.
 - Deployment/release changes should not assume Docker Compose is the production path. TinyCloud
   deploys from GHCR images unless the issue explicitly says otherwise.
+- Release-worthy changes must be visible to release-plz. Use a conventional PR title or merge
+  commit matching `release-plz.toml` (`feat:`, `fix:`, `chore:`, `refactor:`, `perf:`, `docs:`,
+  `ci:`, or `test:`), and confirm the generated release PR changelog includes the user-facing
+  change before treating it as bundled for release.
 - When agent-facing context changes, update this document's additional notes and append a concise
   entry to `agent.changelog.md` so future agents can see what changed and why.
 - Linear issue context matters. Leave concise implementation, testing, and handoff notes on the


### PR DESCRIPTION
## Summary
- add release-plz guidance to `agent.dev.md` for release-worthy changes
- record the guidance change in `agent.changelog.md`

## Context
TC-1388 merged with a non-conventional PR/merge title, while `release-plz.toml` only treats conventional commit subjects as release commits. Future release-worthy changes should use a conventional PR title or merge commit and verify the generated release PR changelog includes the intended user-facing change.

## Verification
- `git diff --check -- agent.dev.md agent.changelog.md`

## Notes
- Docs-only change.