### PR TITLE
chore: hard migrate encryption owner DID column

### DIFF
--- a/tinycloud-core/src/migrations/m20260601_000000_encryption_networks.rs
+++ b/tinycloud-core/src/migrations/m20260601_000000_encryption_networks.rs
@@ -21,11 +21,7 @@ impl MigrationTrait for Migration {
                             .string()
                             .not_null(),
                     )
-                    .col(
-                        ColumnDef::new(encryption_network::Column::OwnerDid)
-                            .string()
-                            .not_null(),
-                    )
+                    .col(ColumnDef::new(Alias::new("principal")).string().not_null())
                     .col(
                         ColumnDef::new(encryption_network::Column::Name)
                             .string()

--- a/tinycloud-core/src/migrations/m20260602_000000_rename_encryption_owner_did.rs
+++ b/tinycloud-core/src/migrations/m20260602_000000_rename_encryption_owner_did.rs
@@ -1,0 +1,37 @@
+use sea_orm_migration::prelude::*;
+
+use crate::models::encryption_network;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(encryption_network::Entity)
+                    .rename_column(
+                        Alias::new("principal"),
+                        encryption_network::Column::OwnerDid,
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(encryption_network::Entity)
+                    .rename_column(
+                        encryption_network::Column::OwnerDid,
+                        Alias::new("principal"),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+}

--- a/tinycloud-core/src/migrations/mod.rs
+++ b/tinycloud-core/src/migrations/mod.rs
@@ -5,6 +5,7 @@ pub mod m20260409_000000_hook_tables;
 pub mod m20260512_000000_signed_kv_tickets;
 pub mod m20260516_000000_database_artifacts;
 pub mod m20260601_000000_encryption_networks;
+pub mod m20260602_000000_rename_encryption_owner_did;
 
 pub struct Migrator;
 
@@ -18,6 +19,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260512_000000_signed_kv_tickets::Migration),
             Box::new(m20260516_000000_database_artifacts::Migration),
             Box::new(m20260601_000000_encryption_networks::Migration),
+            Box::new(m20260602_000000_rename_encryption_owner_did::Migration),
         ]
     }
 }

--- a/tinycloud-core/src/models/encryption_network.rs
+++ b/tinycloud-core/src/models/encryption_network.rs
@@ -5,7 +5,6 @@ use sea_orm::entity::prelude::*;
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false, unique)]
     pub network_id: String,
-    #[sea_orm(column_name = "principal")]
     pub owner_did: String,
     pub name: String,
     pub alg: String,


### PR DESCRIPTION
## Summary
- remove the SeaORM compatibility mapping from encryption_network.owner_did to the old principal column
- add a forward migration that renames the existing encryption_network principal column to owner_did
- keep final runtime/model/schema surfaces on owner_did with no model-level legacy alias

## Validation
- cargo fmt
- cargo test -p tinycloud-core encryption_network
- cargo check -p tinycloud-node
- git diff --check

## Notes
The only remaining principal strings are in the migration history, where they identify the old column being renamed.