### PR TITLE
fix: vendor OpenSSL for aarch64 release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+          echo "CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+          echo "AR_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ar" >> "$GITHUB_ENV"
 
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }} -p tinycloud-node

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9250,6 +9250,7 @@ dependencies = [
  "hmac",
  "hyper 0.14.32",
  "lazy_static",
+ "native-tls",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",

--- a/tinycloud-node-server/Cargo.toml
+++ b/tinycloud-node-server/Cargo.toml
@@ -52,6 +52,11 @@ tracing-log = "0.2"
 tracing-opentelemetry = "0.30"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "json"] }
 
+[target.'cfg(all(target_os = "linux", target_arch = "aarch64"))'.dependencies]
+# Release builds cross-compile aarch64 Linux from x86_64 Linux. Vendoring
+# OpenSSL avoids needing target OpenSSL headers/libs in the runner image.
+native-tls = { version = "0.2.14", features = ["vendored"] }
+
 [dependencies.tinycloud-core]
 path = "../tinycloud-core/"
 default-features = false


### PR DESCRIPTION
## Summary
- enable native-tls vendored OpenSSL only for Linux aarch64 builds
- set CC/AR for the aarch64 GNU cross toolchain in the release workflow
- avoid requiring target OpenSSL headers/libs on the GitHub Actions runner

## Why
The release workflow cross-compiles `aarch64-unknown-linux-gnu` from Ubuntu x86_64. `openssl-sys` was trying to discover a target OpenSSL install and failed with: `Could not find directory of OpenSSL installation`.

## Validation
- `cargo tree -p tinycloud-node -e features --target aarch64-unknown-linux-gnu` confirms `native-tls` / `openssl` / `openssl-sys` vendored features are enabled for aarch64 Linux
- `cargo tree -p tinycloud-node -e features` confirms vendored OpenSSL is not enabled for the host target
- `cargo check -p tinycloud-node`
- `git diff --check`

## Note
Existing failed tag workflows may need a new tag or retag after this merges, because GitHub tag workflows use the workflow file from the tagged commit.
