### PR TITLE
Add telemetry spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The following common options are available:
 | storage.staging     | TINYCLOUD_STORAGE_STAGING     | Set the mode of content staging, options are "Memory" and "FileSystem"     |
 | keys.type           | TINYCLOUD_KEYS_TYPE           | Set the type of host key store, options are "Static"                       |
 | spaces.allowlist    | TINYCLOUD_SPACES_ALLOWLIST    | Set the URL of an allowlist service for gating the creation of Space Peers |
+| telemetry.enabled   | TINYCLOUD_TELEMETRY__ENABLED  | Enable Prometheus latency metrics on the configured Prometheus port        |
 
 ### Database Config
 

--- a/tinycloud-node-server/src/auth_guards.rs
+++ b/tinycloud-node-server/src/auth_guards.rs
@@ -58,13 +58,17 @@ impl<'r> FromData<'r> for DataIn<'r> {
         let span = info_span!(parent: &req_span.0, "data_in");
         // Instrumenting async block to handle yielding properly
         async move {
-            let timer = crate::prometheus::AUTHORIZATION_HISTOGRAM
-                .with_label_values(&["invoke"])
-                .start_timer();
+            let timer = crate::prometheus::enabled().then(|| {
+                crate::prometheus::AUTHORIZATION_HISTOGRAM
+                    .with_label_values(&["invoke"])
+                    .start_timer()
+            });
 
             let res = rocket::outcome::Outcome::Success(DataIn::One(data));
 
-            timer.observe_duration();
+            if let Some(timer) = timer {
+                timer.observe_duration();
+            }
             res
         }
         .instrument(span)

--- a/tinycloud-node-server/src/config.rs
+++ b/tinycloud-node-server/src/config.rs
@@ -21,6 +21,8 @@ pub struct Config {
     #[serde(default)]
     pub hooks: HooksConfig,
     pub relay: Relay,
+    #[serde(default)]
+    pub telemetry: Telemetry,
     pub prometheus: Prometheus,
     pub cors: bool,
     pub keys: Keys,
@@ -371,6 +373,11 @@ pub enum StagingStorage {
 pub struct Relay {
     pub address: String,
     pub port: u16,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Hash, PartialEq, Eq, Default)]
+pub struct Telemetry {
+    pub enabled: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Hash, PartialEq, Eq)]

--- a/tinycloud-node-server/src/lib.rs
+++ b/tinycloud-node-server/src/lib.rs
@@ -113,6 +113,8 @@ pub async fn app(config: &Figment) -> Result<Rocket<Build>> {
     // Remote backends (Postgres, S3) are left alone; connection errors surface naturally.
     ensure_local_dirs(&tinycloud_config.storage).await?;
 
+    prometheus::set_enabled(tinycloud_config.telemetry.enabled);
+
     tracing::tracing_try_init(&tinycloud_config.log)?;
 
     let routes = routes![

--- a/tinycloud-node-server/src/main.rs
+++ b/tinycloud-node-server/src/main.rs
@@ -37,15 +37,19 @@ async fn main() {
         }
     };
 
-    let prom_addr = (rocket.config().address, tinycloud_config.prometheus.port).into();
-    let prometheus = Server::bind(&prom_addr).serve(make_service_fn(|_| async {
-        Ok::<_, hyper::Error>(service_fn(prometheus::serve_req))
-    }));
+    if tinycloud_config.telemetry.enabled {
+        let prom_addr = (rocket.config().address, tinycloud_config.prometheus.port).into();
+        let prometheus = Server::bind(&prom_addr).serve(make_service_fn(|_| async {
+            Ok::<_, hyper::Error>(service_fn(prometheus::serve_req))
+        }));
 
-    tokio::select! {
-        r = rocket.launch() => {let _ = r.unwrap();},
-        r = prometheus => r.unwrap()
-    };
+        tokio::select! {
+            r = rocket.launch() => {let _ = r.unwrap();},
+            r = prometheus => r.unwrap()
+        };
+    } else {
+        let _ = rocket.launch().await.unwrap();
+    }
 }
 
 #[cfg(test)]
@@ -119,6 +123,32 @@ mod tests {
             cfg.storage.database.as_deref(),
             Some("sqlite:/tmp/canonical-storage.db")
         );
+    }
+
+    #[test]
+    fn telemetry_defaults_to_disabled() {
+        let _lock = lock_env();
+        let _legacy = EnvVarGuard::unset("TINYCLOUD_TELEMETRY_ENABLED");
+        let _canonical = EnvVarGuard::unset("TINYCLOUD_TELEMETRY__ENABLED");
+
+        let cfg = build_config_figment()
+            .extract::<config::Config>()
+            .expect("config should parse");
+
+        assert!(!cfg.telemetry.enabled);
+    }
+
+    #[test]
+    fn canonical_double_underscore_loads_telemetry_enabled() {
+        let _lock = lock_env();
+        let _legacy = EnvVarGuard::unset("TINYCLOUD_TELEMETRY_ENABLED");
+        let _canonical = EnvVarGuard::set("TINYCLOUD_TELEMETRY__ENABLED", "true");
+
+        let cfg = build_config_figment()
+            .extract::<config::Config>()
+            .expect("config should parse");
+
+        assert!(cfg.telemetry.enabled);
     }
 
     #[test]

--- a/tinycloud-node-server/src/prometheus.rs
+++ b/tinycloud-node-server/src/prometheus.rs
@@ -1,8 +1,20 @@
 use hyper::{header::CONTENT_TYPE, Body, Request, Response};
 use lazy_static::lazy_static;
 use prometheus::{register_histogram_vec, Encoder, HistogramVec, TextEncoder};
+use std::{
+    sync::atomic::{AtomicBool, Ordering},
+    time::Duration,
+};
+
+static TELEMETRY_ENABLED: AtomicBool = AtomicBool::new(false);
 
 lazy_static! {
+    pub static ref REQUEST_HISTOGRAM: HistogramVec = register_histogram_vec!(
+        "tinycloud_http_request_duration_seconds",
+        "HTTP request latencies in seconds.",
+        &["method", "route", "status"]
+    )
+    .unwrap();
     pub static ref AUTHORIZED_INVOKE_HISTOGRAM: HistogramVec = register_histogram_vec!(
         "tinycloud_authorized_invoke_duration_seconds",
         "The authorized invocations latencies in seconds.",
@@ -15,6 +27,28 @@ lazy_static! {
         &["request"]
     )
     .unwrap();
+    pub static ref SPAN_HISTOGRAM: HistogramVec = register_histogram_vec!(
+        "tinycloud_span_duration_seconds",
+        "Named internal operation latencies in seconds.",
+        &["span", "outcome"]
+    )
+    .unwrap();
+}
+
+pub fn set_enabled(enabled: bool) {
+    TELEMETRY_ENABLED.store(enabled, Ordering::Relaxed);
+}
+
+pub fn enabled() -> bool {
+    TELEMETRY_ENABLED.load(Ordering::Relaxed)
+}
+
+pub fn observe_span(span: &'static str, outcome: &'static str, duration: Duration) {
+    if enabled() {
+        SPAN_HISTOGRAM
+            .with_label_values(&[span, outcome])
+            .observe(duration.as_secs_f64());
+    }
 }
 
 pub async fn serve_req(_req: Request<Body>) -> Result<Response<Body>, hyper::Error> {

--- a/tinycloud-node-server/src/routes/encryption.rs
+++ b/tinycloud-node-server/src/routes/encryption.rs
@@ -9,7 +9,7 @@
 
 use rocket::{form::FromForm, http::Status, serde::json::Json, State};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Instant};
 
 use crate::{authorization::AuthHeaderGetter, BlockStage, TinyCloud};
 use tinycloud_core::encryption_network::{
@@ -52,31 +52,47 @@ pub async fn create_network(
 ) -> Result<Json<DescriptorView>, (Status, String)> {
     let invocation = authorization.0;
     let invocation_info = invocation.0.clone();
-    verify_auth(invocation, tinycloud, service.node_did()).await?;
+    verify_auth(
+        "server.encryption.create.auth",
+        invocation,
+        tinycloud,
+        service.node_did(),
+    )
+    .await?;
 
     let body_value = body.into_inner();
     let body: CreateNetworkBody = serde_json::from_value(body_value.clone())
         .map_err(|err| (Status::BadRequest, err.to_string()))?;
     let network_id = NetworkId::new(body.owner_did.clone(), body.name.clone())
         .map_err(|err| (Status::BadRequest, err.to_string()))?;
-    service
+    let admin_start = Instant::now();
+    let admin_result = service
         .verify_network_admin_authorized(
             &network_id,
             NETWORK_CREATE_ACTION,
             &invocation_info,
             &body_value,
         )
-        .await
-        .map_err(map_service_err)?;
+        .await;
+    crate::prometheus::observe_span(
+        "server.encryption.verify_admin",
+        if admin_result.is_ok() { "ok" } else { "error" },
+        admin_start.elapsed(),
+    );
+    admin_result.map_err(map_service_err)?;
     let req = CreateNetworkRequest {
         name: body.name,
         owner_did: body.owner_did,
         threshold: body.threshold,
     };
-    let descriptor = service
-        .create_one_of_one_network(req)
-        .await
-        .map_err(map_service_err)?;
+    let create_start = Instant::now();
+    let create_result = service.create_one_of_one_network(req).await;
+    crate::prometheus::observe_span(
+        "server.encryption.create_network",
+        if create_result.is_ok() { "ok" } else { "error" },
+        create_start.elapsed(),
+    );
+    let descriptor = create_result.map_err(map_service_err)?;
     Ok(Json(DescriptorView { descriptor }))
 }
 
@@ -91,7 +107,14 @@ pub async fn get_network(
             .map_err(|e: tinycloud_core::encryption_network::NetworkIdError| {
                 (Status::BadRequest, e.to_string())
             })?;
-    let descriptor = service.get_network(&net).await.map_err(map_service_err)?;
+    let start = Instant::now();
+    let result = service.get_network(&net).await;
+    crate::prometheus::observe_span(
+        "server.encryption.get_network",
+        if result.is_ok() { "ok" } else { "error" },
+        start.elapsed(),
+    );
+    let descriptor = result.map_err(map_service_err)?;
     Ok(Json(DescriptorView { descriptor }))
 }
 
@@ -106,10 +129,16 @@ pub async fn well_known_network(
 ) -> Result<Json<WellKnownRecord>, (Status, String)> {
     // V1 supports owner-qualified discovery when the caller has it, and a
     // name-only fallback for single-owner nodes.
-    let descriptor = service
+    let start = Instant::now();
+    let result = service
         .get_network_by_name(name, query.owner_did.as_deref())
-        .await
-        .map_err(map_service_err)?;
+        .await;
+    crate::prometheus::observe_span(
+        "server.encryption.get_network_by_name",
+        if result.is_ok() { "ok" } else { "error" },
+        start.elapsed(),
+    );
+    let descriptor = result.map_err(map_service_err)?;
     Ok(Json(WellKnownRecord::from(&descriptor)))
 }
 
@@ -127,7 +156,13 @@ pub async fn decrypt(
 ) -> Result<Json<DecryptResponseBody>, (Status, String)> {
     let invocation = authorization.0;
     let invocation_info = invocation.0.clone();
-    verify_auth(invocation, tinycloud, service.node_did()).await?;
+    verify_auth(
+        "server.encryption.decrypt.auth",
+        invocation,
+        tinycloud,
+        service.node_did(),
+    )
+    .await?;
 
     let net: NetworkId =
         network_id
@@ -136,10 +171,20 @@ pub async fn decrypt(
                 (Status::BadRequest, e.to_string())
             })?;
     let body = body.into_inner();
-    let verified = service
+    let decrypt_start = Instant::now();
+    let decrypt_result = service
         .decrypt_authorized(&net, &invocation_info, &body)
-        .await
-        .map_err(map_service_err)?;
+        .await;
+    crate::prometheus::observe_span(
+        "server.encryption.decrypt_authorized",
+        if decrypt_result.is_ok() {
+            "ok"
+        } else {
+            "error"
+        },
+        decrypt_start.elapsed(),
+    );
+    let verified = decrypt_result.map_err(map_service_err)?;
     Ok(Json(verified.response))
 }
 
@@ -152,7 +197,13 @@ pub async fn revoke_network(
 ) -> Result<Status, (Status, String)> {
     let invocation = authorization.0;
     let invocation_info = invocation.0.clone();
-    verify_auth(invocation, tinycloud, service.node_did()).await?;
+    verify_auth(
+        "server.encryption.revoke.auth",
+        invocation,
+        tinycloud,
+        service.node_did(),
+    )
+    .await?;
 
     let net: NetworkId =
         network_id
@@ -161,18 +212,29 @@ pub async fn revoke_network(
                 (Status::BadRequest, e.to_string())
             })?;
     let body = serde_json::json!({});
-    service
+    let admin_start = Instant::now();
+    let admin_result = service
         .verify_network_admin_authorized(&net, NETWORK_REVOKE_ACTION, &invocation_info, &body)
-        .await
-        .map_err(map_service_err)?;
-    service
-        .revoke_network(&net)
-        .await
-        .map_err(map_service_err)?;
+        .await;
+    crate::prometheus::observe_span(
+        "server.encryption.verify_revoke_admin",
+        if admin_result.is_ok() { "ok" } else { "error" },
+        admin_start.elapsed(),
+    );
+    admin_result.map_err(map_service_err)?;
+    let revoke_start = Instant::now();
+    let revoke_result = service.revoke_network(&net).await;
+    crate::prometheus::observe_span(
+        "server.encryption.revoke_network",
+        if revoke_result.is_ok() { "ok" } else { "error" },
+        revoke_start.elapsed(),
+    );
+    revoke_result.map_err(map_service_err)?;
     Ok(Status::NoContent)
 }
 
 async fn verify_auth(
+    span: &'static str,
     invocation: Invocation,
     tinycloud: &State<TinyCloud>,
     node_did: &str,
@@ -183,11 +245,18 @@ async fn verify_auth(
             EncryptionServiceError::AudienceMismatch.to_string(),
         ));
     }
-    tinycloud
+    let start = Instant::now();
+    let result = tinycloud
         .invoke::<BlockStage>(invocation, HashMap::new())
         .await
         .map(|_| ())
-        .map_err(|err| (Status::Unauthorized, err.to_string()))
+        .map_err(|err| (Status::Unauthorized, err.to_string()));
+    crate::prometheus::observe_span(
+        span,
+        if result.is_ok() { "ok" } else { "error" },
+        start.elapsed(),
+    );
+    result
 }
 
 fn map_service_err(err: EncryptionServiceError) -> (Status, String) {

--- a/tinycloud-node-server/src/routes/mod.rs
+++ b/tinycloud-node-server/src/routes/mod.rs
@@ -3,7 +3,10 @@ use futures::io::AsyncWriteExt;
 use percent_encoding::percent_decode_str;
 use rocket::{data::ToByteUnit, http::Status, serde::json::Json, State};
 use serde::Serialize;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    time::Instant,
+};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use tinycloud_auth::resource::{Path, SpaceId};
 use tokio::io::AsyncReadExt;
@@ -147,14 +150,21 @@ pub async fn create_signed_kv_url(
     tinycloud: &State<TinyCloud>,
 ) -> Result<Json<SignedKvUrlResponse>, (Status, String)> {
     let invocation_info = invocation.0 .0.clone();
-    verify_auth(invocation.0, tinycloud).await?;
-    let response = mint_signed_kv_url(
+    verify_auth("server.signed_kv.auth", invocation.0, tinycloud).await?;
+    let mint_start = Instant::now();
+    let mint_result = mint_signed_kv_url(
         &invocation_info,
         request.into_inner(),
         runtime.inner(),
         tinycloud.inner(),
     )
-    .await?;
+    .await;
+    crate::prometheus::observe_span(
+        "server.signed_kv.mint_url",
+        if mint_result.is_ok() { "ok" } else { "error" },
+        mint_start.elapsed(),
+    );
+    let response = mint_result?;
     Ok(Json(response))
 }
 
@@ -166,14 +176,24 @@ pub async fn signed_kv_get(
     KVResponse<tinycloud_core::storage::Content<<BlockStores as ImmutableReadStore>::Readable>>,
     (Status, String),
 > {
-    let ticket = load_signed_kv_ticket(tinycloud.inner(), ticket_id).await?;
+    let load_start = Instant::now();
+    let load_result = load_signed_kv_ticket(tinycloud.inner(), ticket_id).await;
+    crate::prometheus::observe_span(
+        "server.signed_kv.load_ticket",
+        if load_result.is_ok() { "ok" } else { "error" },
+        load_start.elapsed(),
+    );
+    let ticket = load_result?;
     let (space_id, key) = validate_signed_kv_ticket(&ticket)?;
 
-    match tinycloud
-        .kv_get(&space_id, &key)
-        .await
-        .map_err(|e| (Status::InternalServerError, e.to_string()))?
-    {
+    let kv_start = Instant::now();
+    let kv_result = tinycloud.kv_get(&space_id, &key).await;
+    crate::prometheus::observe_span(
+        "server.signed_kv.kv_get",
+        if kv_result.is_ok() { "ok" } else { "error" },
+        kv_start.elapsed(),
+    );
+    match kv_result.map_err(|e| (Status::InternalServerError, e.to_string()))? {
         Some((md, hash, content)) => {
             validate_signed_kv_hash_binding(&ticket, &hash)?;
             Ok(KVResponse::new(md, hash, content))
@@ -199,9 +219,11 @@ pub async fn delegate(
     let span = info_span!(parent: &req_span.0, "delegate", action = %action_label);
     // Instrumenting async block to handle yielding properly
     async move {
-        let timer = crate::prometheus::AUTHORIZED_INVOKE_HISTOGRAM
-            .with_label_values(&["delegate"])
-            .start_timer();
+        let timer = crate::prometheus::enabled().then(|| {
+            crate::prometheus::AUTHORIZED_INVOKE_HISTOGRAM
+                .with_label_values(&["delegate"])
+                .start_timer()
+        });
         let res = tinycloud
             .delegate(d.0)
             .await
@@ -242,7 +264,9 @@ pub async fn delegate(
                     skipped,
                 }))
             });
-        timer.observe_duration();
+        if let Some(timer) = timer {
+            timer.observe_duration();
+        }
         res
     }
     .instrument(span)
@@ -629,9 +653,11 @@ async fn invoke_impl(
     let span = info_span!(parent: &req_span.0, "invoke", action = %action_label);
     // Instrumenting async block to handle yielding properly
     async move {
-        let timer = crate::prometheus::AUTHORIZED_INVOKE_HISTOGRAM
-            .with_label_values(&["invoke"])
-            .start_timer();
+        let timer = crate::prometheus::enabled().then(|| {
+            crate::prometheus::AUTHORIZED_INVOKE_HISTOGRAM
+                .with_label_values(&["invoke"])
+                .start_timer()
+        });
 
         // Check for SQL capabilities
         let sql_caps: Vec<_> = i
@@ -663,7 +689,9 @@ async fn invoke_impl(
                 &sql_caps,
             )
             .await;
-            timer.observe_duration();
+            if let Some(timer) = timer {
+                timer.observe_duration();
+            }
             return result;
         }
 
@@ -704,7 +732,9 @@ async fn invoke_impl(
                     arrow_format,
                 )
                 .await;
-                timer.observe_duration();
+                if let Some(timer) = timer {
+                    timer.observe_duration();
+                }
                 return result;
             }
         }
@@ -718,7 +748,9 @@ async fn invoke_impl(
                         && ability.starts_with("tinycloud.duckdb/")
             )
         }) {
-            timer.observe_duration();
+            if let Some(timer) = timer {
+                timer.observe_duration();
+            }
             return Err((
                 Status::NotImplemented,
                 "DuckDB support is not enabled on this node".to_string(),
@@ -739,8 +771,10 @@ async fn invoke_impl(
                 .collect::<Vec<_>>()
         });
 
-        let inputs = match (data, put_caps.as_slice(), is_multipart_request) {
-            (DataIn::None | DataIn::One(_), [], _) => HashMap::new(),
+        let staging_start = Instant::now();
+        let inputs_result: Result<KvInputMap, (Status, String)> =
+            match (data, put_caps.as_slice(), is_multipart_request) {
+                (DataIn::None | DataIn::One(_), [], _) => Ok(HashMap::new()),
             (DataIn::One(d), [(space, path)], false) => {
                 let mut stage = staging
                     .stage(space)
@@ -802,10 +836,9 @@ async fn invoke_impl(
 
                 let mut inputs = HashMap::new();
                 inputs.insert((space.clone(), path.clone()), (headers.0, stage));
-                inputs
+                Ok(inputs)
             }
-            (DataIn::One(d), [_, ..], true) => {
-                build_batch_kv_inputs(
+                (DataIn::One(d), [_, ..], true) => build_batch_kv_inputs(
                     d,
                     &headers,
                     expected_batch_inputs
@@ -816,17 +849,28 @@ async fn invoke_impl(
                     config,
                     quota_cache,
                 )
-                .await?
-            }
-            (DataIn::One(_), [_, _, ..], false) => {
-                return Err((Status::BadRequest, "KV batch put requires multipart/form-data".to_string()));
-            }
-            _ => {
-                return Err((Status::BadRequest, "Invalid inputs".to_string()));
-            }
-        };
+                .await,
+                (DataIn::One(_), [_, _, ..], false) => Err((
+                    Status::BadRequest,
+                    "KV batch put requires multipart/form-data".to_string(),
+                )),
+                _ => Err((Status::BadRequest, "Invalid inputs".to_string())),
+            };
+        crate::prometheus::observe_span(
+            "server.kv.stage_inputs",
+            if inputs_result.is_ok() { "ok" } else { "error" },
+            staging_start.elapsed(),
+        );
+        let inputs = inputs_result?;
         let invocation_info = i.0 .0.clone();
-        let res = match tinycloud.invoke::<BlockStage>(i.0, inputs).await {
+        let invoke_start = Instant::now();
+        let invoke_result = tinycloud.invoke::<BlockStage>(i.0, inputs).await;
+        crate::prometheus::observe_span(
+            "server.kv.invoke",
+            if invoke_result.is_ok() { "ok" } else { "error" },
+            invoke_start.elapsed(),
+        );
+        let res = match invoke_result {
             Ok((tx_result, mut outcomes)) => {
                 emit_kv_hook_events(hook_runtime, tinycloud, &invocation_info, &tx_result).await;
                 if let Some(written_paths) = batch_written_paths {
@@ -869,7 +913,9 @@ async fn invoke_impl(
             )),
         };
 
-        timer.observe_duration();
+        if let Some(timer) = timer {
+            timer.observe_duration();
+        }
         res
     }
     .instrument(span)
@@ -1059,8 +1105,15 @@ async fn handle_sql_invoke(
             });
 
     let actor = i.0 .0.invoker.clone();
-    let auth_result = verify_auth(i.0, tinycloud).await?;
-    let body_str = read_json_body(data).await?;
+    let auth_result = verify_auth("server.sql.auth", i.0, tinycloud).await?;
+    let body_start = Instant::now();
+    let body_result = read_json_body(data).await;
+    crate::prometheus::observe_span(
+        "server.sql.read_body",
+        if body_result.is_ok() { "ok" } else { "error" },
+        body_start.elapsed(),
+    );
+    let body_str = body_result?;
 
     let (space, path, ability) = select_database_scope(sql_caps, "sql")?;
     let db_name = SqlService::db_name_from_path(path);
@@ -1070,17 +1123,31 @@ async fn handle_sql_invoke(
         serde_json::from_str(&body_str).map_err(|e| (Status::BadRequest, e.to_string()))?;
 
     if matches!(sql_request, SqlRequest::Export) {
-        let data = sql_service
-            .export(space, &db_name)
-            .await
-            .map_err(|e| (sql_error_to_status(&e), e.to_string()))?;
+        let export_start = Instant::now();
+        let export_result = sql_service.export(space, &db_name).await;
+        crate::prometheus::observe_span(
+            "server.sql.export",
+            if export_result.is_ok() { "ok" } else { "error" },
+            export_start.elapsed(),
+        );
+        let data = export_result.map_err(|e| (sql_error_to_status(&e), e.to_string()))?;
         return Ok(DataOut::One(InvOut(InvocationOutcome::SqlExport(data))));
     }
 
-    let response = sql_service
+    let execute_start = Instant::now();
+    let execute_result = sql_service
         .execute(space, &db_name, sql_request, caveats, ability.to_string())
-        .await
-        .map_err(|e| (sql_error_to_status(&e), e.to_string()))?;
+        .await;
+    crate::prometheus::observe_span(
+        "server.sql.execute",
+        if execute_result.is_ok() {
+            "ok"
+        } else {
+            "error"
+        },
+        execute_start.elapsed(),
+    );
+    let response = execute_result.map_err(|e| (sql_error_to_status(&e), e.to_string()))?;
 
     if let Some(epoch) = auth_result
         .commits
@@ -1098,14 +1165,23 @@ async fn handle_sql_invoke(
                 &response.write_targets,
             );
 
-            enqueue_database_webhook_deliveries(tinycloud, &events)
-                .await
-                .map_err(|e| {
-                    (
-                        Status::InternalServerError,
-                        format!("sql write committed but webhook enqueue failed: {e}"),
-                    )
-                })?;
+            let enqueue_start = Instant::now();
+            let enqueue_result = enqueue_database_webhook_deliveries(tinycloud, &events).await;
+            crate::prometheus::observe_span(
+                "server.sql.enqueue_hooks",
+                if enqueue_result.is_ok() {
+                    "ok"
+                } else {
+                    "error"
+                },
+                enqueue_start.elapsed(),
+            );
+            enqueue_result.map_err(|e| {
+                (
+                    Status::InternalServerError,
+                    format!("sql write committed but webhook enqueue failed: {e}"),
+                )
+            })?;
 
             publish_database_hook_events(hook_runtime, &events);
         }
@@ -1157,7 +1233,7 @@ async fn handle_duckdb_invoke(
             });
 
     let actor = i.0 .0.invoker.clone();
-    let auth_result = verify_auth(i.0, tinycloud).await?;
+    let auth_result = verify_auth("server.duckdb.auth", i.0, tinycloud).await?;
 
     let (space, path, ability) = select_database_scope(duckdb_caps, "duckdb")?;
     let db_name = DuckDbService::db_name_from_path(path);
@@ -1182,16 +1258,27 @@ async fn handle_duckdb_invoke(
             }
         };
 
-        duckdb_service
-            .import_db(space, &db_name, &body_bytes)
-            .await
-            .map_err(|e| (duckdb_error_to_status(&e), e.to_string()))?;
+        let import_start = Instant::now();
+        let import_result = duckdb_service.import_db(space, &db_name, &body_bytes).await;
+        crate::prometheus::observe_span(
+            "server.duckdb.import",
+            if import_result.is_ok() { "ok" } else { "error" },
+            import_start.elapsed(),
+        );
+        import_result.map_err(|e| (duckdb_error_to_status(&e), e.to_string()))?;
 
         let json = serde_json::json!({"imported": true});
         return Ok(DataOut::One(InvOut(InvocationOutcome::DuckDbResult(json))));
     }
 
-    let body_str = read_json_body(data).await?;
+    let body_start = Instant::now();
+    let body_result = read_json_body(data).await;
+    crate::prometheus::observe_span(
+        "server.duckdb.read_body",
+        if body_result.is_ok() { "ok" } else { "error" },
+        body_start.elapsed(),
+    );
+    let body_str = body_result?;
 
     let duckdb_request: DuckDbRequest =
         serde_json::from_str(&body_str).map_err(|e| (Status::BadRequest, e.to_string()))?;
@@ -1203,14 +1290,19 @@ async fn handle_duckdb_invoke(
                 "Export not allowed with active caveats".into(),
             ));
         }
-        let data = duckdb_service
-            .export(space, &db_name)
-            .await
-            .map_err(|e| (duckdb_error_to_status(&e), e.to_string()))?;
+        let export_start = Instant::now();
+        let export_result = duckdb_service.export(space, &db_name).await;
+        crate::prometheus::observe_span(
+            "server.duckdb.export",
+            if export_result.is_ok() { "ok" } else { "error" },
+            export_start.elapsed(),
+        );
+        let data = export_result.map_err(|e| (duckdb_error_to_status(&e), e.to_string()))?;
         return Ok(DataOut::One(InvOut(InvocationOutcome::DuckDbExport(data))));
     }
 
-    let response = duckdb_service
+    let execute_start = Instant::now();
+    let execute_result = duckdb_service
         .execute(
             space,
             &db_name,
@@ -1219,8 +1311,17 @@ async fn handle_duckdb_invoke(
             ability.to_string(),
             arrow_format,
         )
-        .await
-        .map_err(|e| (duckdb_error_to_status(&e), e.to_string()))?;
+        .await;
+    crate::prometheus::observe_span(
+        "server.duckdb.execute",
+        if execute_result.is_ok() {
+            "ok"
+        } else {
+            "error"
+        },
+        execute_start.elapsed(),
+    );
+    let response = execute_result.map_err(|e| (duckdb_error_to_status(&e), e.to_string()))?;
 
     if let Some(epoch) = auth_result
         .commits
@@ -1238,14 +1339,23 @@ async fn handle_duckdb_invoke(
                 &response.write_targets,
             );
 
-            enqueue_database_webhook_deliveries(tinycloud, &events)
-                .await
-                .map_err(|e| {
-                    (
-                        Status::InternalServerError,
-                        format!("duckdb write committed but webhook enqueue failed: {e}"),
-                    )
-                })?;
+            let enqueue_start = Instant::now();
+            let enqueue_result = enqueue_database_webhook_deliveries(tinycloud, &events).await;
+            crate::prometheus::observe_span(
+                "server.duckdb.enqueue_hooks",
+                if enqueue_result.is_ok() {
+                    "ok"
+                } else {
+                    "error"
+                },
+                enqueue_start.elapsed(),
+            );
+            enqueue_result.map_err(|e| {
+                (
+                    Status::InternalServerError,
+                    format!("duckdb write committed but webhook enqueue failed: {e}"),
+                )
+            })?;
 
             publish_database_hook_events(hook_runtime, &events);
         }
@@ -1498,10 +1608,12 @@ fn preferred_database_ability<'a>(
 /// schema block partially applies and then fails, MVP does not emit hooks for
 /// the partial write set.
 async fn verify_auth(
+    span: &'static str,
     invocation: Invocation,
     tinycloud: &State<TinyCloud>,
 ) -> Result<TransactResult, (Status, String)> {
-    tinycloud
+    let start = Instant::now();
+    let result = tinycloud
         .invoke::<BlockStage>(invocation, HashMap::new())
         .await
         .map_err(|e| {
@@ -1516,7 +1628,13 @@ async fn verify_auth(
                 e.to_string(),
             )
         })
-        .map(|(tx_result, _)| tx_result)
+        .map(|(tx_result, _)| tx_result);
+    crate::prometheus::observe_span(
+        span,
+        if result.is_ok() { "ok" } else { "error" },
+        start.elapsed(),
+    );
+    result
 }
 
 #[cfg(test)]

--- a/tinycloud-node-server/src/tracing.rs
+++ b/tinycloud-node-server/src/tracing.rs
@@ -6,6 +6,7 @@ use rocket::{
     request::{FromRequest, Outcome},
     Data, Request, Response,
 };
+use std::time::Instant;
 use tracing::{field, info_span, subscriber::set_global_default, Span};
 use tracing_log::LogTracer;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
@@ -15,6 +16,11 @@ use crate::config;
 
 #[derive(Clone)]
 pub struct TracingSpan(pub Span);
+
+#[derive(Clone)]
+struct RequestTelemetry {
+    start: Instant,
+}
 
 pub struct TracingFairing {
     pub header_name: String,
@@ -35,6 +41,13 @@ impl Fairing for TracingFairing {
             field::display(&span.context().span().span_context().trace_id()),
         );
         req.local_cache(|| Some(TracingSpan(span)));
+        if crate::prometheus::enabled() {
+            req.local_cache(|| {
+                Some(RequestTelemetry {
+                    start: Instant::now(),
+                })
+            });
+        }
     }
 
     async fn on_response<'r>(&self, req: &'r Request<'_>, res: &mut Response<'r>) {
@@ -42,6 +55,24 @@ impl Fairing for TracingFairing {
         {
             let trace_id = span.context().span().span_context().trace_id();
             res.set_raw_header(self.header_name.clone(), format!("{trace_id}"));
+        }
+        if crate::prometheus::enabled() {
+            if let Some(telemetry) = req
+                .local_cache(|| Option::<RequestTelemetry>::None)
+                .to_owned()
+            {
+                let route = req
+                    .route()
+                    .map(|route| route.uri.to_string())
+                    .unwrap_or_else(|| req.uri().path().to_string());
+                crate::prometheus::REQUEST_HISTOGRAM
+                    .with_label_values(&[
+                        req.method().as_str(),
+                        route.as_str(),
+                        res.status().code.to_string().as_str(),
+                    ])
+                    .observe(telemetry.start.elapsed().as_secs_f64());
+            }
         }
     }
 }

--- a/tinycloud.toml
+++ b/tinycloud.toml
@@ -34,3 +34,8 @@ cors = true
 [global.spaces]
 ## Space allow list api endpoint
 # allowlist = "http://localhost:10000"
+
+[global.telemetry]
+    ## Enable Prometheus latency metrics on global.prometheus.port.
+    ## Env: TINYCLOUD_TELEMETRY__ENABLED
+    enabled = false


### PR DESCRIPTION
## Summary
- add default-off telemetry config for tinycloud-node
- expose Prometheus request and named span histograms when telemetry is enabled
- instrument auth, KV, SQL, DuckDB, signed KV, and encryption paths with named spans

## Verification
- cargo test -p tinycloud-node telemetry
- end-to-end benchmark smoke from js-sdk against local tinycloud-node
- curl http://localhost:8001/metrics showed request and named span histograms
- git diff --check