### PR TITLE
Require SQL admin for PRAGMA

### DIFF
--- a/tinycloud-core/src/sql/parser.rs
+++ b/tinycloud-core/src/sql/parser.rs
@@ -6,6 +6,7 @@ use super::caveats::SqlCaveats;
 use super::types::SqlError;
 use crate::write_hooks::TouchedTables;
 
+#[derive(Debug)]
 pub struct ParsedQuery {
     pub statements: Vec<Statement>,
     pub referenced_tables: Vec<String>,
@@ -20,6 +21,23 @@ pub fn validate_sql(
     caveats: &Option<SqlCaveats>,
     ability: &str,
 ) -> Result<ParsedQuery, SqlError> {
+    if is_pragma_sql(sql) {
+        if !matches!(ability, "tinycloud.sql/admin" | "tinycloud.sql/*") {
+            return Err(SqlError::PermissionDenied(
+                "PRAGMA operations require admin ability".to_string(),
+            ));
+        }
+
+        return Ok(ParsedQuery {
+            statements: Vec::new(),
+            referenced_tables: Vec::new(),
+            referenced_columns: Vec::new(),
+            write_targets: Vec::new(),
+            is_read_only: true,
+            is_ddl: false,
+        });
+    }
+
     let dialect = SQLiteDialect {};
     let statements =
         Parser::parse_sql(&dialect, sql).map_err(|e| SqlError::ParseError(e.to_string()))?;
@@ -139,6 +157,43 @@ pub fn validate_sql(
         is_read_only,
         is_ddl,
     })
+}
+
+pub fn is_pragma_sql(sql: &str) -> bool {
+    first_sql_token(sql).as_deref() == Some("pragma")
+}
+
+fn first_sql_token(sql: &str) -> Option<String> {
+    let mut index = 0;
+
+    while index < sql.len() {
+        while let Some(ch) = sql[index..].chars().next() {
+            if !ch.is_whitespace() {
+                break;
+            }
+            index += ch.len_utf8();
+        }
+
+        if sql[index..].starts_with("--") {
+            let newline = sql[index + 2..].find('\n')?;
+            index += 2 + newline + 1;
+            continue;
+        }
+
+        if sql[index..].starts_with("/*") {
+            let end = sql[index + 2..].find("*/")?;
+            index += 2 + end + 2;
+            continue;
+        }
+
+        break;
+    }
+
+    let token: String = sql[index..]
+        .chars()
+        .take_while(|ch| ch.is_ascii_alphabetic() || *ch == '_')
+        .collect();
+    (!token.is_empty()).then(|| token.to_ascii_lowercase())
 }
 
 fn extract_tables_from_statement(stmt: &Statement, tables: &mut Vec<String>) {
@@ -332,5 +387,34 @@ mod tests {
 
         let targets = extract_write_targets_from_statement(&statements[0]).unwrap();
         assert_eq!(targets, TouchedTables::supported(vec!["users".to_string()]));
+    }
+
+    #[test]
+    fn pragma_requires_admin_before_generic_sql_parse() {
+        let err = validate_sql(
+            "PRAGMA table_info(secret_records)",
+            &None,
+            "tinycloud.sql/read",
+        )
+        .expect_err("read ability must not authorize PRAGMA");
+
+        assert!(matches!(err, SqlError::PermissionDenied(message) if message.contains("admin")));
+    }
+
+    #[test]
+    fn admin_pragma_is_validated_without_sqlparser() {
+        let parsed = validate_sql(
+            "
+              -- migration introspection
+              /* SQLite-specific */
+              PRAGMA table_info(secret_records)
+            ",
+            &None,
+            "tinycloud.sql/admin",
+        )
+        .expect("admin PRAGMA should not fail sqlparser parsing");
+
+        assert!(parsed.is_read_only);
+        assert!(parsed.write_targets.is_empty());
     }
 }

--- a/tinycloud-node-server/src/routes/mod.rs
+++ b/tinycloud-node-server/src/routes/mod.rs
@@ -36,7 +36,7 @@ use tinycloud_core::{
     sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder},
     sql::{SqlCaveats, SqlError, SqlRequest, SqlService},
     storage::{HashBuffer, ImmutableReadStore, ImmutableStaging},
-    types::{Metadata, Resource},
+    types::{Ability, Metadata, Resource},
     util::{Capability, DelegationInfo, InvocationInfo},
     write_hooks::{db_table_path, hook_delivery_id, subscription_matches_event, TouchedTables},
     InvocationOutcome, TransactResult, TxError, TxStoreError,
@@ -1069,6 +1069,8 @@ async fn handle_sql_invoke(
     let sql_request: SqlRequest =
         serde_json::from_str(&body_str).map_err(|e| (Status::BadRequest, e.to_string()))?;
 
+    require_sql_admin_for_request(&sql_request, space, path, &db_name, sql_caps)?;
+
     if matches!(sql_request, SqlRequest::Export) {
         let data = sql_service
             .export(space, &db_name)
@@ -1115,6 +1117,40 @@ async fn handle_sql_invoke(
         .map_err(|e| (Status::InternalServerError, e.to_string()))?;
 
     Ok(DataOut::One(InvOut(InvocationOutcome::SqlResult(json))))
+}
+
+fn require_sql_admin_for_request(
+    request: &SqlRequest,
+    space: &SpaceId,
+    path: Option<&str>,
+    db_name: &str,
+    caps: &[(SpaceId, Option<String>, String)],
+) -> Result<(), (Status, String)> {
+    if !sql_request_requires_admin(request) || has_database_admin_capability(caps, "sql") {
+        return Ok(());
+    }
+
+    Err(missing_database_admin_capability_error(
+        space, path, db_name, "sql",
+    ))
+}
+
+fn sql_request_requires_admin(request: &SqlRequest) -> bool {
+    match request {
+        SqlRequest::Query { sql, .. } => tinycloud_core::sql::parser::is_pragma_sql(sql),
+        SqlRequest::Execute { sql, schema, .. } => {
+            tinycloud_core::sql::parser::is_pragma_sql(sql)
+                || schema.as_ref().is_some_and(|statements| {
+                    statements
+                        .iter()
+                        .any(|statement| tinycloud_core::sql::parser::is_pragma_sql(statement))
+                })
+        }
+        SqlRequest::Batch { statements } => statements
+            .iter()
+            .any(|statement| tinycloud_core::sql::parser::is_pragma_sql(&statement.sql)),
+        SqlRequest::ExecuteStatement { .. } | SqlRequest::Export => false,
+    }
 }
 
 fn sql_error_to_status(err: &SqlError) -> Status {
@@ -1490,6 +1526,46 @@ fn preferred_database_ability<'a>(
     })
 }
 
+fn has_database_admin_capability(
+    caps: &[(tinycloud_auth::resource::SpaceId, Option<String>, String)],
+    service: &str,
+) -> bool {
+    let admin_abilities: &[&str] = match service {
+        "sql" => &["tinycloud.sql/admin", "tinycloud.sql/*"],
+        "duckdb" => &["tinycloud.duckdb/admin", "tinycloud.duckdb/*"],
+        _ => &[],
+    };
+
+    caps.iter()
+        .any(|(_, _, ability)| admin_abilities.contains(&ability.as_str()))
+}
+
+fn missing_database_admin_capability_error(
+    space: &tinycloud_auth::resource::SpaceId,
+    path: Option<&str>,
+    db_name: &str,
+    service: &str,
+) -> (Status, String) {
+    let ability = match service {
+        "sql" => "tinycloud.sql/admin",
+        "duckdb" => "tinycloud.duckdb/admin",
+        _ => "tinycloud.kv/put",
+    };
+    let resource_path = path.unwrap_or(db_name).parse().unwrap();
+    let resource = Resource::TinyCloud(space.clone().to_resource(
+        service.parse().unwrap(),
+        Some(resource_path),
+        None,
+        None,
+    ));
+    let ability = Ability::try_from(ability.to_string()).unwrap();
+
+    (
+        Status::Unauthorized,
+        format!("Unauthorized Action: {resource} / {ability}"),
+    )
+}
+
 /// Verify authorization by invoking with empty inputs.
 ///
 /// Shared by SQL and DuckDB invoke handlers. The caller must extract caveats
@@ -1584,6 +1660,57 @@ mod tests {
             )),
             ability: Ability::try_from("tinycloud.sql/read".to_string()).unwrap(),
         }
+    }
+
+    #[tokio::test]
+    async fn sql_pragma_request_requires_admin() {
+        let request = SqlRequest::Query {
+            sql: "PRAGMA table_info(secret_records)".to_string(),
+            params: Vec::new(),
+        };
+
+        assert!(sql_request_requires_admin(&request));
+    }
+
+    #[tokio::test]
+    async fn sql_pragma_missing_admin_returns_auth_hint_shape() {
+        let space = test_space_id("secrets");
+        let request = SqlRequest::Query {
+            sql: "PRAGMA table_info(secret_records)".to_string(),
+            params: Vec::new(),
+        };
+        let caps = vec![(
+            space.clone(),
+            Some("default".to_string()),
+            "tinycloud.sql/read".to_string(),
+        )];
+
+        let err =
+            require_sql_admin_for_request(&request, &space, Some("default"), "default", &caps)
+                .expect_err("PRAGMA with only read should ask for admin");
+
+        assert_eq!(err.0, Status::Unauthorized);
+        assert_eq!(
+            err.1,
+            format!("Unauthorized Action: {space}/sql/default / tinycloud.sql/admin")
+        );
+    }
+
+    #[tokio::test]
+    async fn sql_pragma_admin_capability_is_accepted() {
+        let space = test_space_id("secrets");
+        let request = SqlRequest::Query {
+            sql: "PRAGMA table_info(secret_records)".to_string(),
+            params: Vec::new(),
+        };
+        let caps = vec![(
+            space.clone(),
+            Some("default".to_string()),
+            "tinycloud.sql/admin".to_string(),
+        )];
+
+        require_sql_admin_for_request(&request, &space, Some("default"), "default", &caps)
+            .expect("admin PRAGMA should be accepted");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Detect SQLite PRAGMA requests before the generic SQL parser
- Return the existing `Unauthorized Action: <resource> / tinycloud.sql/admin` auth error when a PRAGMA request lacks SQL admin capability
- Allow admin-authorized PRAGMA statements to bypass sqlparser so SQLite can execute them directly
- Add parser and route tests for the missing-admin auth hint shape

## Verification
- `cargo test -p tinycloud-core sql::parser::tests`
- `cargo test -p tinycloud-node routes::tests::sql_pragma`

Context: js-sdk PR #248 is a client-side improvement, but this PR is the authoritative tinycloud-node fix.