### PR TITLE
fix(sql): authorize SQLITE_REINDEX so CREATE INDEX succeeds

### DIFF
--- a/tinycloud-core/src/sql/authorizer.rs
+++ b/tinycloud-core/src/sql/authorizer.rs
@@ -312,4 +312,67 @@ mod tests {
             Authorization::Deny
         );
     }
+
+    /// Install the authorizer on a real rusqlite connection (mirroring the
+    /// wiring in database.rs) and run `sql` under the given cap.
+    fn execute_under_authorizer(
+        conn: &rusqlite::Connection,
+        ability: &str,
+        is_admin: bool,
+        sql: &str,
+    ) -> rusqlite::Result<()> {
+        let auth = create_authorizer(None, ability.to_string(), is_admin);
+        conn.authorizer(Some(auth));
+        let result = conn.execute_batch(sql);
+        conn.authorizer(None::<fn(AuthContext<'_>) -> Authorization>);
+        result
+    }
+
+    #[test]
+    fn create_unique_index_executes_with_write_cap() {
+        // End-to-end against real SQLite: the CreateIndex -> Reindex callback
+        // sequence fired while building the index must pass under a write cap.
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        execute_under_authorizer(
+            &conn,
+            "tinycloud.sql/write",
+            false,
+            "CREATE TABLE interaction (reader_did TEXT, nonce TEXT)",
+        )
+        .unwrap();
+
+        execute_under_authorizer(
+            &conn,
+            "tinycloud.sql/write",
+            false,
+            "CREATE UNIQUE INDEX uq_interaction_nonce ON interaction (reader_did, nonce)",
+        )
+        .expect("CREATE UNIQUE INDEX should succeed with a write cap");
+    }
+
+    #[test]
+    fn create_unique_index_blocked_with_read_only_cap() {
+        // Set up the table with a write cap, then attempt the index under a
+        // read-only cap: SQLite must report "not authorized".
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        execute_under_authorizer(
+            &conn,
+            "tinycloud.sql/write",
+            false,
+            "CREATE TABLE interaction (reader_did TEXT, nonce TEXT)",
+        )
+        .unwrap();
+
+        let err = execute_under_authorizer(
+            &conn,
+            "tinycloud.sql/read",
+            false,
+            "CREATE UNIQUE INDEX uq_interaction_nonce ON interaction (reader_did, nonce)",
+        )
+        .expect_err("CREATE UNIQUE INDEX must be denied for a read-only cap");
+        assert!(
+            err.to_string().contains("not authorized"),
+            "expected an authorization error, got: {err}"
+        );
+    }
 }

--- a/tinycloud-core/src/sql/authorizer.rs
+++ b/tinycloud-core/src/sql/authorizer.rs
@@ -215,7 +215,10 @@ pub fn create_authorizer(
         | AuthAction::CreateTempTrigger { .. }
         | AuthAction::DropTempTrigger { .. }
         | AuthAction::CreateTempView { .. }
-        | AuthAction::DropTempView { .. } => {
+        | AuthAction::DropTempView { .. }
+        // SQLite fires SQLITE_REINDEX while building an index; gate it like the
+        // CreateIndex it accompanies so an authorized CREATE INDEX can complete.
+        | AuthAction::Reindex { .. } => {
             if !is_admin && !matches!(ability.as_str(), "tinycloud.sql/write" | "tinycloud.sql/*") {
                 Authorization::Deny
             } else {
@@ -230,5 +233,83 @@ pub fn create_authorizer(
 
         // Deny everything else
         _ => Authorization::Deny,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn authorize(ability: &str, is_admin: bool, action: AuthAction<'_>) -> Authorization {
+        let mut auth = create_authorizer(None, ability.to_string(), is_admin);
+        auth(AuthContext {
+            action,
+            database_name: Some("main"),
+            accessor: None,
+        })
+    }
+
+    #[test]
+    fn create_index_allowed_with_write_ability() {
+        // CREATE [UNIQUE] INDEX fires CreateIndex followed by Reindex while the
+        // index is built; both must pass for the statement to succeed.
+        let create_index = AuthAction::CreateIndex {
+            index_name: "uq_interaction_nonce",
+            table_name: "interaction",
+        };
+        let reindex = AuthAction::Reindex {
+            index_name: "uq_interaction_nonce",
+        };
+
+        assert_eq!(
+            authorize("tinycloud.sql/write", false, create_index),
+            Authorization::Allow
+        );
+        assert_eq!(
+            authorize("tinycloud.sql/write", false, reindex),
+            Authorization::Allow
+        );
+    }
+
+    #[test]
+    fn create_index_allowed_for_admin() {
+        let create_index = AuthAction::CreateIndex {
+            index_name: "uq_interaction_nonce",
+            table_name: "interaction",
+        };
+        let reindex = AuthAction::Reindex {
+            index_name: "uq_interaction_nonce",
+        };
+
+        assert_eq!(
+            authorize("tinycloud.sql/read", true, create_index),
+            Authorization::Allow
+        );
+        assert_eq!(
+            authorize("tinycloud.sql/read", true, reindex),
+            Authorization::Allow
+        );
+    }
+
+    #[test]
+    fn create_index_denied_without_write() {
+        let create_index = AuthAction::CreateIndex {
+            index_name: "uq_interaction_nonce",
+            table_name: "interaction",
+        };
+        let reindex = AuthAction::Reindex {
+            index_name: "uq_interaction_nonce",
+        };
+
+        assert_eq!(
+            authorize("tinycloud.sql/read", false, create_index),
+            Authorization::Deny
+        );
+        // Reindex must be gated identically to CreateIndex: a read-only cap
+        // cannot sneak an index build through the companion callback.
+        assert_eq!(
+            authorize("tinycloud.sql/read", false, reindex),
+            Authorization::Deny
+        );
     }
 }


### PR DESCRIPTION
## Problem

`CREATE INDEX` / `CREATE UNIQUE INDEX` fail with `400 SQLite error: not authorized` even for a space **owner** with full admin, while `CREATE TABLE`/`DROP`/`ALTER` succeed.

**Root cause:** When SQLite builds an index it fires a `SQLITE_REINDEX` authorizer callback (`AuthAction::Reindex`). `create_authorizer()` in `tinycloud-core/src/sql/authorizer.rs` had no match arm for `Reindex`, so it fell through to the catch-all `_ => Authorization::Deny`. `CREATE TABLE` works because it never fires `Reindex`. This blocks the storage-layer `uq_interaction_nonce` unique index used for nonce replay protection.

## Fix

Add an `AuthAction::Reindex { .. }` arm to the existing DDL **allow** branch, gated **identically** to the `CreateIndex` it accompanies:

```
is_admin || ability in { tinycloud.sql/write, tinycloud.sql/* }
```

Reindex is the index-build companion to an already-authorized `CreateIndex`, so it is gated the same way. This does **not** broaden authorization — a read-only cap still cannot build an index.

## Tests

Added unit tests in the authorizer module (construct `AuthContext` directly):
- `CreateIndex` + `Reindex` **allowed** with `tinycloud.sql/write`
- `CreateIndex` + `Reindex` **allowed** for `is_admin`
- `CreateIndex` + `Reindex` **denied** with read-only (`tinycloud.sql/read`)

```
test sql::authorizer::tests::create_index_denied_without_write ... ok
test sql::authorizer::tests::create_index_allowed_with_write_ability ... ok
test sql::authorizer::tests::create_index_allowed_for_admin ... ok
```

`cargo build`, `cargo fmt --check`, and `cargo clippy -p tinycloud-core` all clean.

## Deploy note

Security-critical authorization change. **Holding merge/deploy** — the live `node.tinycloud.xyz` redeploy is a separate user-controlled step per deploy-auditability.