### PR TITLE
Suppress duplicate invoke requests

### DIFF
--- a/tinycloud-auth/src/authorization.rs
+++ b/tinycloud-auth/src/authorization.rs
@@ -217,3 +217,42 @@ pub enum EncodingError {
 pub enum CapabilitiesQuery {
     All,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resolver::DID_METHODS;
+
+    #[test]
+    fn invocation_options_default_mints_nonce() {
+        let jwk = JWK::generate_ed25519().expect("jwk");
+        let mut verification_method = DID_METHODS.generate(&jwk, "key").expect("did").to_string();
+        let fragment = verification_method
+            .rsplit_once(':')
+            .expect("did has fragment material")
+            .1
+            .to_string();
+        verification_method.push('#');
+        verification_method.push_str(&fragment);
+
+        let invocation = make_invocation_from_uris(
+            [(
+                "tinycloud://example/kv/path".parse::<UriString>().unwrap(),
+                ["tinycloud.kv/get".parse::<Ability>().unwrap()],
+            )],
+            &Cid::default(),
+            &jwk,
+            &verification_method,
+            4_102_444_800.0,
+            InvocationOptions::default(),
+        )
+        .expect("invocation");
+
+        let nonce = invocation
+            .payload()
+            .nonce
+            .as_deref()
+            .expect("default invocation nonce");
+        assert!(nonce.starts_with("urn:uuid:"));
+    }
+}

--- a/tinycloud-core/src/events/mod.rs
+++ b/tinycloud-core/src/events/mod.rs
@@ -36,6 +36,14 @@ impl<T> SerializedEvent<T> {
             .map_err(FromReqErr::from)
             .and_then(|(i, s)| Ok(Self(T::try_from(i).map_err(FromReqErr::TryFrom)?, s)))
     }
+
+    pub fn serialized_bytes(&self) -> &[u8] {
+        &self.1
+    }
+
+    pub fn content_hash(&self) -> Hash {
+        hash(self.serialized_bytes())
+    }
 }
 
 pub type Delegation = SerializedEvent<DelegationInfo>;

--- a/tinycloud-node-server/src/invocation_replay.rs
+++ b/tinycloud-node-server/src/invocation_replay.rs
@@ -1,0 +1,99 @@
+use std::collections::HashMap;
+
+use rocket::http::Status;
+use time::{Duration, OffsetDateTime};
+use tinycloud_core::{events::Invocation, hash::Hash};
+use tokio::sync::Mutex;
+
+const CLOCK_SKEW_SECONDS: i64 = 60;
+
+#[derive(Debug, thiserror::Error)]
+pub enum InvocationReplayError {
+    #[error("duplicate invocation")]
+    Duplicate,
+}
+
+#[derive(Default)]
+pub struct InvocationReplayCache {
+    seen: Mutex<HashMap<Hash, OffsetDateTime>>,
+}
+
+impl InvocationReplayCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn check_and_insert(
+        &self,
+        invocation: &Invocation,
+    ) -> Result<(), InvocationReplayError> {
+        let now = OffsetDateTime::now_utc();
+        let key = invocation.content_hash();
+        let expires_at = invocation_expires_at(invocation, now);
+        self.check_and_insert_key(key, expires_at, now).await
+    }
+
+    async fn check_and_insert_key(
+        &self,
+        key: Hash,
+        expires_at: OffsetDateTime,
+        now: OffsetDateTime,
+    ) -> Result<(), InvocationReplayError> {
+        let mut seen = self.seen.lock().await;
+        seen.retain(|_, expires_at| *expires_at > now);
+
+        if seen.contains_key(&key) {
+            return Err(InvocationReplayError::Duplicate);
+        }
+
+        seen.insert(key, expires_at);
+        Ok(())
+    }
+}
+
+impl From<InvocationReplayError> for (Status, String) {
+    fn from(err: InvocationReplayError) -> Self {
+        match err {
+            InvocationReplayError::Duplicate => (Status::Conflict, err.to_string()),
+        }
+    }
+}
+
+fn invocation_expires_at(invocation: &Invocation, now: OffsetDateTime) -> OffsetDateTime {
+    OffsetDateTime::from_unix_timestamp(
+        invocation.0.invocation.payload().expiration.as_seconds() as i64 + CLOCK_SKEW_SECONDS,
+    )
+    .unwrap_or(now + Duration::seconds(CLOCK_SKEW_SECONDS))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tinycloud_core::hash::hash;
+
+    #[tokio::test]
+    async fn duplicate_key_is_rejected_until_entry_expires() {
+        let cache = InvocationReplayCache::new();
+        let key = hash(b"invocation");
+        let now = OffsetDateTime::now_utc();
+
+        assert!(cache
+            .check_and_insert_key(key, now + Duration::seconds(60), now)
+            .await
+            .is_ok());
+        assert!(matches!(
+            cache
+                .check_and_insert_key(key, now + Duration::seconds(60), now)
+                .await,
+            Err(InvocationReplayError::Duplicate)
+        ));
+        assert!(cache
+            .check_and_insert_key(
+                key,
+                now + Duration::seconds(120),
+                now + Duration::seconds(61)
+            )
+            .await
+            .is_ok());
+    }
+}

--- a/tinycloud-node-server/src/lib.rs
+++ b/tinycloud-node-server/src/lib.rs
@@ -16,6 +16,7 @@ pub mod config;
 #[cfg(feature = "dstack")]
 pub mod dstack;
 pub mod hooks;
+pub mod invocation_replay;
 pub mod prometheus;
 pub mod quota;
 pub mod routes;
@@ -27,6 +28,7 @@ pub mod webhook_dispatcher;
 
 use config::{BlockStorage, Config, Keys, StagingStorage};
 use hooks::HookRuntime;
+use invocation_replay::InvocationReplayCache;
 use quota::QuotaCache;
 use routes::{
     admin::{delete_quota, get_quota, list_quotas, set_quota},
@@ -265,6 +267,7 @@ pub async fn app(config: &Figment) -> Result<Rocket<Build>> {
         tinycloud_config.storage.limit,
         std::env::var("TINYCLOUD_QUOTA_URL").ok(),
     );
+    let invocation_replay_cache = InvocationReplayCache::new();
 
     let rate_limiter = RateLimiter::new(&tinycloud_config.public_spaces);
     let webhook_dispatcher = WebhookDispatcher::new(
@@ -286,6 +289,7 @@ pub async fn app(config: &Figment) -> Result<Rocket<Build>> {
     let rocket = rocket.manage(duckdb_service);
     let rocket = rocket
         .manage(quota_cache)
+        .manage(invocation_replay_cache)
         .manage(hook_runtime)
         .manage(signed_url_runtime)
         .manage(webhook_encryption)

--- a/tinycloud-node-server/src/routes/mod.rs
+++ b/tinycloud-node-server/src/routes/mod.rs
@@ -3168,7 +3168,6 @@ mod tests {
         .insert(&conn)
         .await?;
 
-        let mut invocation_caps = Capabilities::new();
         let mut invocation_nb = std::collections::BTreeMap::new();
         for (key, value) in constrained_caveat
             .as_object()
@@ -3176,24 +3175,28 @@ mod tests {
         {
             invocation_nb.insert(key.clone(), value.clone());
         }
-        invocation_caps.with_action(
-            sql_resource.as_uri(),
-            "tinycloud.sql/read".parse::<UcanAbility>()?,
-            [invocation_nb],
-        );
         let parent_cid: AuthCid = delegation_hash.to_cid(0x55);
-        let invocation = Payload {
-            issuer: holder_verification_method.parse::<DIDURLBuf>()?,
-            audience: holder_did.parse::<DIDBuf>()?,
-            not_before: None,
-            expiration: NumericDate::try_from_seconds(4_102_444_800.0)?,
-            nonce: Some("urn:uuid:00000000-0000-4000-8000-0000000000w5".to_string()),
-            facts: Some(Vec::<serde_json::Value>::new()),
-            proof: vec![parent_cid],
-            attenuation: invocation_caps,
-        }
-        .sign(holder_jwk.get_algorithm().unwrap_or_default(), &holder_jwk)?;
-        let auth_header = invocation.encode()?;
+        let make_auth_header = |nonce: &str| -> Result<String> {
+            let mut invocation_caps = Capabilities::new();
+            invocation_caps.with_action(
+                sql_resource.as_uri(),
+                "tinycloud.sql/read".parse::<UcanAbility>()?,
+                [invocation_nb.clone()],
+            );
+            let invocation = Payload {
+                issuer: holder_verification_method.parse::<DIDURLBuf>()?,
+                audience: holder_did.parse::<DIDBuf>()?,
+                not_before: None,
+                expiration: NumericDate::try_from_seconds(4_102_444_800.0)?,
+                nonce: Some(nonce.to_string()),
+                facts: Some(Vec::<serde_json::Value>::new()),
+                proof: vec![parent_cid],
+                attenuation: invocation_caps,
+            }
+            .sign(holder_jwk.get_algorithm().unwrap_or_default(), &holder_jwk)?;
+            Ok(invocation.encode()?)
+        };
+        let auth_header = make_auth_header("urn:uuid:00000000-0000-4000-8000-0000000000w5")?;
 
         let rocket = rocket::build()
             .mount("/", routes![invoke])
@@ -3204,6 +3207,7 @@ mod tests {
             .manage(sql_service)
             .manage(Config::default())
             .manage(QuotaCache::new(None, None))
+            .manage(InvocationReplayCache::new())
             .manage(hook_runtime)
             .manage(BlockStage::from(crate::config::StagingStorage::Memory));
 
@@ -3236,6 +3240,7 @@ mod tests {
         .insert(&conn)
         .await?;
 
+        let auth_header = make_auth_header("urn:uuid:00000000-0000-4000-8000-0000000000w6")?;
         let response = client
             .post("/invoke")
             .header(Header::new("Authorization", auth_header.clone()))

--- a/tinycloud-node-server/src/routes/mod.rs
+++ b/tinycloud-node-server/src/routes/mod.rs
@@ -18,6 +18,7 @@ use crate::{
     authorization::AuthHeaderGetter,
     config::Config,
     hooks::{HookRuntime, WriteEvent},
+    invocation_replay::InvocationReplayCache,
     quota::QuotaCache,
     routes::public::is_public_space,
     signed_urls::{
@@ -329,6 +330,7 @@ pub async fn invoke(
     tinycloud: &State<TinyCloud>,
     config: &State<Config>,
     quota_cache: &State<QuotaCache>,
+    invocation_replay_cache: &State<InvocationReplayCache>,
     sql_service: &State<SqlService>,
     duckdb_service: &State<DuckDbService>,
     hook_runtime: &State<HookRuntime>,
@@ -342,6 +344,7 @@ pub async fn invoke(
         tinycloud,
         config,
         quota_cache,
+        invocation_replay_cache,
         sql_service,
         duckdb_service,
         hook_runtime,
@@ -361,6 +364,7 @@ pub async fn invoke(
     tinycloud: &State<TinyCloud>,
     config: &State<Config>,
     quota_cache: &State<QuotaCache>,
+    invocation_replay_cache: &State<InvocationReplayCache>,
     sql_service: &State<SqlService>,
     hook_runtime: &State<HookRuntime>,
 ) -> Result<DataOut<<BlockStores as ImmutableReadStore>::Readable>, (Status, String)> {
@@ -373,6 +377,7 @@ pub async fn invoke(
         tinycloud,
         config,
         quota_cache,
+        invocation_replay_cache,
         sql_service,
         (),
         hook_runtime,
@@ -687,6 +692,7 @@ async fn invoke_impl(
     tinycloud: &State<TinyCloud>,
     config: &State<Config>,
     quota_cache: &State<QuotaCache>,
+    invocation_replay_cache: &State<InvocationReplayCache>,
     sql_service: &State<SqlService>,
     #[cfg_attr(not(feature = "duckdb"), allow(unused_variables))] duckdb_service: DuckDbInvokeState<
         '_,
@@ -702,6 +708,8 @@ async fn invoke_impl(
                 .with_label_values(&["invoke"])
                 .start_timer()
         });
+
+        invocation_replay_cache.check_and_insert(&i.0).await?;
 
         // Check for SQL capabilities
         let sql_caps: Vec<_> = i
@@ -2892,7 +2900,6 @@ mod tests {
         .await?;
 
         let parent_cid: AuthCid = parent_hash.to_cid(0x55);
-        let mut invocation_caps = Capabilities::new();
         let mut invocation_nb = std::collections::BTreeMap::new();
         for (key, value) in constrained_caveat
             .as_object()
@@ -2900,38 +2907,42 @@ mod tests {
         {
             invocation_nb.insert(key.clone(), value.clone());
         }
-        invocation_caps.with_action(
-            sql_resource.as_uri(),
-            "tinycloud.sql/read".parse::<UcanAbility>()?,
-            [invocation_nb],
-        );
-        let invocation = Payload {
-            issuer: verification_method.parse::<DIDURLBuf>()?,
-            audience: verification_method
-                .split('#')
-                .next()
-                .ok_or_else(|| anyhow::anyhow!("missing did"))?
-                .parse::<DIDBuf>()?,
-            not_before: None,
-            expiration: NumericDate::try_from_seconds(4_102_444_800.0)?,
-            nonce: Some("urn:uuid:00000000-0000-4000-8000-000000000001".to_string()),
-            // If the route trusted invocation facts over the persisted chain
-            // caveat, this prepared statement would return 999 instead of
-            // the chain-pinned alpha row value 111.
-            facts: Some(vec![json!({
-                "sqlCaveats": {
-                    "readOnly": true,
-                    "statements": [{
-                        "name": "get_val",
-                        "sql": "SELECT 999 WHERE ? = 'alpha'"
-                    }]
-                }
-            })]),
-            proof: vec![parent_cid],
-            attenuation: invocation_caps,
-        }
-        .sign(jwk.get_algorithm().unwrap_or_default(), &jwk)?;
-        let auth_header = invocation.encode()?;
+        let make_auth_header = |nonce: &str| -> Result<String> {
+            let mut invocation_caps = Capabilities::new();
+            invocation_caps.with_action(
+                sql_resource.as_uri(),
+                "tinycloud.sql/read".parse::<UcanAbility>()?,
+                [invocation_nb.clone()],
+            );
+            let invocation = Payload {
+                issuer: verification_method.parse::<DIDURLBuf>()?,
+                audience: verification_method
+                    .split('#')
+                    .next()
+                    .ok_or_else(|| anyhow::anyhow!("missing did"))?
+                    .parse::<DIDBuf>()?,
+                not_before: None,
+                expiration: NumericDate::try_from_seconds(4_102_444_800.0)?,
+                nonce: Some(nonce.to_string()),
+                // If the route trusted invocation facts over the persisted chain
+                // caveat, this prepared statement would return 999 instead of
+                // the chain-pinned alpha row value 111.
+                facts: Some(vec![json!({
+                    "sqlCaveats": {
+                        "readOnly": true,
+                        "statements": [{
+                            "name": "get_val",
+                            "sql": "SELECT 999 WHERE ? = 'alpha'"
+                        }]
+                    }
+                })]),
+                proof: vec![parent_cid],
+                attenuation: invocation_caps,
+            }
+            .sign(jwk.get_algorithm().unwrap_or_default(), &jwk)?;
+            Ok(invocation.encode()?)
+        };
+        let auth_header = make_auth_header("urn:uuid:00000000-0000-4000-8000-000000000001")?;
 
         let rocket = rocket::build()
             .mount("/", routes![invoke])
@@ -2942,6 +2953,7 @@ mod tests {
             .manage(sql_service)
             .manage(Config::default())
             .manage(QuotaCache::new(None, None))
+            .manage(InvocationReplayCache::new())
             .manage(hook_runtime)
             .manage(BlockStage::from(crate::config::StagingStorage::Memory));
 
@@ -2964,6 +2976,22 @@ mod tests {
         assert_eq!(json["rowCount"], 1);
         assert_eq!(json["rows"][0][0], 111);
 
+        let response = client
+            .post("/invoke")
+            .header(Header::new("Authorization", auth_header.clone()))
+            .header(ContentType::JSON)
+            .body(serde_json::to_string(&SqlRequest::ExecuteStatement {
+                name: "get_val".to_string(),
+                params: vec![],
+            })?)
+            .dispatch()
+            .await;
+        assert_eq!(
+            response.status(),
+            Status::Conflict,
+            "exact invocation replay must be rejected"
+        );
+
         let revocation_hash = tinycloud_core::hash::hash(b"w1-rocket-http-revocation");
         revo_model::ActiveModel {
             id: Set(revocation_hash),
@@ -2974,6 +3002,7 @@ mod tests {
         .insert(&conn)
         .await?;
 
+        let auth_header = make_auth_header("urn:uuid:00000000-0000-4000-8000-000000000002")?;
         let response = client
             .post("/invoke")
             .header(Header::new("Authorization", auth_header.clone()))


### PR DESCRIPTION
## Summary
- add an in-memory invocation replay cache keyed by the signed invocation digest
- reject exact duplicate /invoke requests with 409 before dispatching service handlers
- keep nonce optional at the server boundary while asserting the shared invocation builder mints a UUID nonce by default

## Validation
- cargo test -p tinycloud-node invocation_replay::tests::duplicate_key_is_rejected_until_entry_expires
- cargo test -p tinycloud-node routes::tests::w1_rocket_http_invoke_enforces_chain_constrained_sql_and_revoke
- cargo test -p tinycloud-auth authorization::tests::invocation_options_default_mints_nonce
- cargo check -p tinycloud-node
- git diff --check

Note: cargo fmt --check still reports pre-existing formatting drift in tinycloud-core/src/policy_capability/mod.rs, which this PR does not touch.