### PR TITLE
Support SQL DDL capability

### DIFF
--- a/tinycloud-core/src/sql/authorizer.rs
+++ b/tinycloud-core/src/sql/authorizer.rs
@@ -219,7 +219,12 @@ pub fn create_authorizer(
         // SQLite fires SQLITE_REINDEX while building an index; gate it like the
         // CreateIndex it accompanies so an authorized CREATE INDEX can complete.
         | AuthAction::Reindex { .. } => {
-            if !is_admin && !matches!(ability.as_str(), "tinycloud.sql/write" | "tinycloud.sql/*") {
+            if !is_admin
+                && !matches!(
+                    ability.as_str(),
+                    "tinycloud.sql/write" | "tinycloud.sql/ddl" | "tinycloud.sql/*"
+                )
+            {
                 Authorization::Deny
             } else {
                 Authorization::Allow

--- a/tinycloud-core/src/sql/parser.rs
+++ b/tinycloud-core/src/sql/parser.rs
@@ -109,11 +109,11 @@ pub fn validate_sql(
     if is_ddl
         && !matches!(
             ability,
-            "tinycloud.sql/admin" | "tinycloud.sql/write" | "tinycloud.sql/*"
+            "tinycloud.sql/admin" | "tinycloud.sql/write" | "tinycloud.sql/ddl" | "tinycloud.sql/*"
         )
     {
         return Err(SqlError::PermissionDenied(
-            "DDL operations require admin or write ability".to_string(),
+            "DDL operations require admin, write, or ddl ability".to_string(),
         ));
     }
 
@@ -416,5 +416,18 @@ mod tests {
 
         assert!(parsed.is_read_only);
         assert!(parsed.write_targets.is_empty());
+    }
+
+    #[test]
+    fn validate_sql_allows_ddl_ability_for_schema_changes() {
+        let parsed = validate_sql(
+            "CREATE TABLE IF NOT EXISTS notes (id INTEGER PRIMARY KEY, body TEXT)",
+            &None,
+            "tinycloud.sql/ddl",
+        )
+        .expect("ddl ability should allow schema changes");
+
+        assert!(parsed.is_ddl);
+        assert!(!parsed.is_read_only);
     }
 }

--- a/tinycloud-core/src/sql/service.rs
+++ b/tinycloud-core/src/sql/service.rs
@@ -238,6 +238,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn sql_ddl_ability_can_create_schema() {
+        let repo = artifact_repository().await;
+        let cache = TempDir::new().unwrap();
+        let space = test_space_id("sql-ddl");
+        let service = SqlService::new(cache.path().to_string_lossy().to_string(), u64::MAX, repo);
+
+        service
+            .execute(
+                &space,
+                "main",
+                SqlRequest::Execute {
+                    schema: None,
+                    sql: "CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL)"
+                        .to_string(),
+                    params: Vec::new(),
+                },
+                None,
+                "tinycloud.sql/ddl".to_string(),
+            )
+            .await
+            .expect("ddl ability should create tables");
+    }
+
+    #[tokio::test]
     async fn sql_write_survives_service_recreation_with_empty_cache() {
         let repo = artifact_repository().await;
         let cache_one = TempDir::new().unwrap();

--- a/tinycloud-node-server/src/routes/mod.rs
+++ b/tinycloud-node-server/src/routes/mod.rs
@@ -1999,6 +1999,7 @@ fn preferred_database_ability<'a>(
     let preferred_abilities: &[&str] = match service {
         "sql" => &[
             "tinycloud.sql/write",
+            "tinycloud.sql/ddl",
             "tinycloud.sql/admin",
             "tinycloud.sql/*",
             "tinycloud.sql/read",
@@ -2395,6 +2396,22 @@ mod tests {
         assert_eq!(selected_space, &space);
         assert_eq!(selected_path, Some("main.db"));
         assert_eq!(ability, "tinycloud.sql/write");
+    }
+
+    #[tokio::test]
+    async fn select_database_scope_accepts_sql_ddl_ability() {
+        let space = test_space_id("alpha");
+        let caps = vec![(
+            space.clone(),
+            Some("main.db".to_string()),
+            "tinycloud.sql/ddl".to_string(),
+        )];
+
+        let (selected_space, selected_path, ability) = select_database_scope(&caps, "sql").unwrap();
+
+        assert_eq!(selected_space, &space);
+        assert_eq!(selected_path, Some("main.db"));
+        assert_eq!(ability, "tinycloud.sql/ddl");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary\n- allow tinycloud.sql/ddl through SQL parser validation and SQLite authorizer\n- include ddl in SQL database ability selection\n- add focused parser, service, and route tests\n\n## Tests\n- cargo test -p tinycloud-core sql_ddl_ability_can_create_schema\n- cargo test -p tinycloud-core validate_sql_allows_ddl_ability_for_schema_changes\n- cargo test -p tinycloud-node select_database_scope_accepts_sql_ddl_ability\n- bun test tests/node-sdk/sql/sql-basics.test.ts (from js-sdk, against local node)