### PR TITLE
Accept SQL schema permission

### DIFF
--- a/tinycloud-core/src/sql/authorizer.rs
+++ b/tinycloud-core/src/sql/authorizer.rs
@@ -222,7 +222,10 @@ pub fn create_authorizer(
             if !is_admin
                 && !matches!(
                     ability.as_str(),
-                    "tinycloud.sql/write" | "tinycloud.sql/ddl" | "tinycloud.sql/*"
+                    "tinycloud.sql/write"
+                        | "tinycloud.sql/schema"
+                        | "tinycloud.sql/ddl"
+                        | "tinycloud.sql/*"
                 )
             {
                 Authorization::Deny

--- a/tinycloud-core/src/sql/parser.rs
+++ b/tinycloud-core/src/sql/parser.rs
@@ -109,11 +109,15 @@ pub fn validate_sql(
     if is_ddl
         && !matches!(
             ability,
-            "tinycloud.sql/admin" | "tinycloud.sql/write" | "tinycloud.sql/ddl" | "tinycloud.sql/*"
+            "tinycloud.sql/admin"
+                | "tinycloud.sql/write"
+                | "tinycloud.sql/schema"
+                | "tinycloud.sql/ddl"
+                | "tinycloud.sql/*"
         )
     {
         return Err(SqlError::PermissionDenied(
-            "DDL operations require admin, write, or ddl ability".to_string(),
+            "Schema operations require admin, write, or schema ability".to_string(),
         ));
     }
 
@@ -419,13 +423,26 @@ mod tests {
     }
 
     #[test]
-    fn validate_sql_allows_ddl_ability_for_schema_changes() {
+    fn validate_sql_allows_schema_ability_for_schema_changes() {
+        let parsed = validate_sql(
+            "CREATE TABLE IF NOT EXISTS notes (id INTEGER PRIMARY KEY, body TEXT)",
+            &None,
+            "tinycloud.sql/schema",
+        )
+        .expect("schema ability should allow schema changes");
+
+        assert!(parsed.is_ddl);
+        assert!(!parsed.is_read_only);
+    }
+
+    #[test]
+    fn validate_sql_accepts_legacy_ddl_ability_for_schema_changes() {
         let parsed = validate_sql(
             "CREATE TABLE IF NOT EXISTS notes (id INTEGER PRIMARY KEY, body TEXT)",
             &None,
             "tinycloud.sql/ddl",
         )
-        .expect("ddl ability should allow schema changes");
+        .expect("legacy ddl ability should allow schema changes");
 
         assert!(parsed.is_ddl);
         assert!(!parsed.is_read_only);

--- a/tinycloud-core/src/sql/service.rs
+++ b/tinycloud-core/src/sql/service.rs
@@ -238,10 +238,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sql_ddl_ability_can_create_schema() {
+    async fn sql_schema_ability_can_create_schema() {
         let repo = artifact_repository().await;
         let cache = TempDir::new().unwrap();
-        let space = test_space_id("sql-ddl");
+        let space = test_space_id("sql-schema");
         let service = SqlService::new(cache.path().to_string_lossy().to_string(), u64::MAX, repo);
 
         service
@@ -255,10 +255,10 @@ mod tests {
                     params: Vec::new(),
                 },
                 None,
-                "tinycloud.sql/ddl".to_string(),
+                "tinycloud.sql/schema".to_string(),
             )
             .await
-            .expect("ddl ability should create tables");
+            .expect("schema ability should create tables");
     }
 
     #[tokio::test]

--- a/tinycloud-node-server/src/routes/mod.rs
+++ b/tinycloud-node-server/src/routes/mod.rs
@@ -1999,6 +1999,7 @@ fn preferred_database_ability<'a>(
     let preferred_abilities: &[&str] = match service {
         "sql" => &[
             "tinycloud.sql/write",
+            "tinycloud.sql/schema",
             "tinycloud.sql/ddl",
             "tinycloud.sql/admin",
             "tinycloud.sql/*",
@@ -2399,7 +2400,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn select_database_scope_accepts_sql_ddl_ability() {
+    async fn select_database_scope_accepts_sql_schema_ability() {
+        let space = test_space_id("alpha");
+        let caps = vec![(
+            space.clone(),
+            Some("main.db".to_string()),
+            "tinycloud.sql/schema".to_string(),
+        )];
+
+        let (selected_space, selected_path, ability) = select_database_scope(&caps, "sql").unwrap();
+
+        assert_eq!(selected_space, &space);
+        assert_eq!(selected_path, Some("main.db"));
+        assert_eq!(ability, "tinycloud.sql/schema");
+    }
+
+    #[tokio::test]
+    async fn select_database_scope_accepts_legacy_sql_ddl_ability() {
         let space = test_space_id("alpha");
         let caps = vec![(
             space.clone(),


### PR DESCRIPTION
## Summary
- accept `tinycloud.sql/schema` for SQLite schema-changing statements
- keep `tinycloud.sql/ddl` accepted as a legacy compatibility alias
- prefer `schema` when selecting SQL database capabilities

## Tests
- `cargo test -p tinycloud-core schema --lib`
- `cargo test -p tinycloud-node select_database_scope_accepts --lib`
