### PR TITLE
Drop SQL DDL permission

### DIFF
--- a/tinycloud-core/src/sql/authorizer.rs
+++ b/tinycloud-core/src/sql/authorizer.rs
@@ -224,7 +224,6 @@ pub fn create_authorizer(
                     ability.as_str(),
                     "tinycloud.sql/write"
                         | "tinycloud.sql/schema"
-                        | "tinycloud.sql/ddl"
                         | "tinycloud.sql/*"
                 )
             {

--- a/tinycloud-core/src/sql/parser.rs
+++ b/tinycloud-core/src/sql/parser.rs
@@ -112,7 +112,6 @@ pub fn validate_sql(
             "tinycloud.sql/admin"
                 | "tinycloud.sql/write"
                 | "tinycloud.sql/schema"
-                | "tinycloud.sql/ddl"
                 | "tinycloud.sql/*"
         )
     {
@@ -436,15 +435,14 @@ mod tests {
     }
 
     #[test]
-    fn validate_sql_accepts_legacy_ddl_ability_for_schema_changes() {
-        let parsed = validate_sql(
+    fn validate_sql_rejects_ddl_ability_for_schema_changes() {
+        let err = validate_sql(
             "CREATE TABLE IF NOT EXISTS notes (id INTEGER PRIMARY KEY, body TEXT)",
             &None,
             "tinycloud.sql/ddl",
         )
-        .expect("legacy ddl ability should allow schema changes");
+        .expect_err("ddl ability is not a schema permission");
 
-        assert!(parsed.is_ddl);
-        assert!(!parsed.is_read_only);
+        assert!(matches!(err, SqlError::PermissionDenied(_)));
     }
 }

--- a/tinycloud-node-server/src/routes/mod.rs
+++ b/tinycloud-node-server/src/routes/mod.rs
@@ -1940,7 +1940,7 @@ fn select_database_scope<'a>(
     ),
     (Status, String),
 > {
-    let Some((space, _path, ability)) = caps.first() else {
+    let Some((space, _path, _ability)) = caps.first() else {
         return Err((
             Status::BadRequest,
             format!("No {service} capabilities found"),
@@ -1959,11 +1959,14 @@ fn select_database_scope<'a>(
 
     let path_ref = select_database_path(caps, service)?;
 
-    Ok((
-        space,
-        path_ref,
-        preferred_database_ability(caps, service).unwrap_or(ability.as_str()),
-    ))
+    let Some(ability) = preferred_database_ability(caps, service) else {
+        return Err((
+            Status::Unauthorized,
+            format!("No supported {service} capabilities found"),
+        ));
+    };
+
+    Ok((space, path_ref, ability))
 }
 
 fn select_database_path<'a>(
@@ -2000,7 +2003,6 @@ fn preferred_database_ability<'a>(
         "sql" => &[
             "tinycloud.sql/write",
             "tinycloud.sql/schema",
-            "tinycloud.sql/ddl",
             "tinycloud.sql/admin",
             "tinycloud.sql/*",
             "tinycloud.sql/read",
@@ -2416,19 +2418,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn select_database_scope_accepts_legacy_sql_ddl_ability() {
+    async fn select_database_scope_rejects_sql_ddl_ability() {
         let space = test_space_id("alpha");
         let caps = vec![(
-            space.clone(),
+            space,
             Some("main.db".to_string()),
             "tinycloud.sql/ddl".to_string(),
         )];
 
-        let (selected_space, selected_path, ability) = select_database_scope(&caps, "sql").unwrap();
+        let err = select_database_scope(&caps, "sql").unwrap_err();
 
-        assert_eq!(selected_space, &space);
-        assert_eq!(selected_path, Some("main.db"));
-        assert_eq!(ability, "tinycloud.sql/ddl");
+        assert_eq!(err.0, Status::Unauthorized);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- remove server-side acceptance of `tinycloud.sql/ddl`
- keep `tinycloud.sql/schema`, write/admin, and wildcard as the schema-change paths
- tighten database scope selection so unknown SQL abilities are rejected instead of falling through

## Tests
- `cargo test -p tinycloud-core schema --lib`
- `cargo test -p tinycloud-node select_database_scope --lib`
