### PR TITLE
Bound DID resolution and allow SQL schema grants

### DIFF
--- a/tinycloud-core/src/models/delegation.rs
+++ b/tinycloud-core/src/models/delegation.rs
@@ -1,18 +1,17 @@
 use crate::encryption::ColumnEncryption;
 use crate::encryption_network::NetworkId;
 use crate::hash::Hash;
+use crate::models::did_resolution::did_resolution_timeout;
 use crate::policy_capability::sql_caveat;
 use crate::types::{Ability, Caveats, Facts, Resource};
 use crate::util::DelegationMode;
 use crate::{events::Delegation, models::*, relationships::*, util};
 use sea_orm::{entity::prelude::*, sea_query::OnConflict, ConnectionTrait};
-use std::{collections::BTreeMap, time::Duration};
+use std::collections::BTreeMap;
 use time::OffsetDateTime;
 use tinycloud_auth::{
     authorization::TinyCloudDelegation, identity::did_principal_matches, ssi::dids::AnyDidMethod,
 };
-
-const DID_RESOLUTION_TIMEOUT: Duration = Duration::from_secs(3);
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "delegation")]
@@ -158,7 +157,7 @@ async fn verify(delegation: &TinyCloudDelegation) -> Result<(), Error> {
     match delegation {
         TinyCloudDelegation::Ucan(ref ucan) => {
             tokio::time::timeout(
-                DID_RESOLUTION_TIMEOUT,
+                did_resolution_timeout(),
                 // TODO go back to static DID_METHODS
                 ucan.verify_signature(&AnyDidMethod::default()),
             )

--- a/tinycloud-core/src/models/delegation.rs
+++ b/tinycloud-core/src/models/delegation.rs
@@ -6,11 +6,13 @@ use crate::types::{Ability, Caveats, Facts, Resource};
 use crate::util::DelegationMode;
 use crate::{events::Delegation, models::*, relationships::*, util};
 use sea_orm::{entity::prelude::*, sea_query::OnConflict, ConnectionTrait};
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, time::Duration};
 use time::OffsetDateTime;
 use tinycloud_auth::{
     authorization::TinyCloudDelegation, identity::did_principal_matches, ssi::dids::AnyDidMethod,
 };
+
+const DID_RESOLUTION_TIMEOUT: Duration = Duration::from_secs(3);
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "delegation")]
@@ -155,10 +157,14 @@ pub(crate) async fn process<C: ConnectionTrait>(
 async fn verify(delegation: &TinyCloudDelegation) -> Result<(), Error> {
     match delegation {
         TinyCloudDelegation::Ucan(ref ucan) => {
-            // TODO go back to static DID_METHODS
-            ucan.verify_signature(&AnyDidMethod::default())
-                .await
-                .map_err(|_| DelegationError::InvalidSignature)?;
+            tokio::time::timeout(
+                DID_RESOLUTION_TIMEOUT,
+                // TODO go back to static DID_METHODS
+                ucan.verify_signature(&AnyDidMethod::default()),
+            )
+            .await
+            .map_err(|_| DelegationError::InvalidSignature)?
+            .map_err(|_| DelegationError::InvalidSignature)?;
             ucan.payload()
                 .validate_time(None)
                 .map_err(|_| DelegationError::InvalidTime)?;

--- a/tinycloud-core/src/models/did_resolution.rs
+++ b/tinycloud-core/src/models/did_resolution.rs
@@ -1,0 +1,67 @@
+use std::{env, time::Duration};
+
+pub(crate) const DID_RESOLUTION_TIMEOUT_ENV: &str = "TINYCLOUD_DID_RESOLUTION_TIMEOUT_MS";
+const DEFAULT_DID_RESOLUTION_TIMEOUT: Duration = Duration::from_secs(3);
+
+pub(crate) fn did_resolution_timeout() -> Duration {
+    env::var(DID_RESOLUTION_TIMEOUT_ENV)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .map(Duration::from_millis)
+        .unwrap_or(DEFAULT_DID_RESOLUTION_TIMEOUT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn restore_env(previous: Option<std::ffi::OsString>) {
+        match previous {
+            Some(value) => env::set_var(DID_RESOLUTION_TIMEOUT_ENV, value),
+            None => env::remove_var(DID_RESOLUTION_TIMEOUT_ENV),
+        }
+    }
+
+    #[test]
+    fn uses_default_timeout_when_env_is_missing() {
+        let _guard = env_lock().lock().unwrap();
+        let previous = env::var_os(DID_RESOLUTION_TIMEOUT_ENV);
+
+        env::remove_var(DID_RESOLUTION_TIMEOUT_ENV);
+        assert_eq!(did_resolution_timeout(), Duration::from_secs(3));
+
+        restore_env(previous);
+    }
+
+    #[test]
+    fn uses_timeout_from_env_milliseconds() {
+        let _guard = env_lock().lock().unwrap();
+        let previous = env::var_os(DID_RESOLUTION_TIMEOUT_ENV);
+
+        env::set_var(DID_RESOLUTION_TIMEOUT_ENV, "1250");
+        assert_eq!(did_resolution_timeout(), Duration::from_millis(1250));
+
+        restore_env(previous);
+    }
+
+    #[test]
+    fn invalid_env_uses_default_timeout() {
+        let _guard = env_lock().lock().unwrap();
+        let previous = env::var_os(DID_RESOLUTION_TIMEOUT_ENV);
+
+        env::set_var(DID_RESOLUTION_TIMEOUT_ENV, "invalid");
+        assert_eq!(did_resolution_timeout(), Duration::from_secs(3));
+
+        env::set_var(DID_RESOLUTION_TIMEOUT_ENV, "0");
+        assert_eq!(did_resolution_timeout(), Duration::from_secs(3));
+
+        restore_env(previous);
+    }
+}

--- a/tinycloud-core/src/models/invocation.rs
+++ b/tinycloud-core/src/models/invocation.rs
@@ -15,11 +15,14 @@ use sea_orm::{
 };
 use serde::Serialize;
 use std::collections::HashMap;
+use std::time::Duration;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use tinycloud_auth::{
     authorization::TinyCloudInvocation, identity::did_principal_matches, resource::Path,
     ssi::dids::AnyDidMethod,
 };
+
+const DID_RESOLUTION_TIMEOUT: Duration = Duration::from_secs(3);
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "invocation")]
@@ -117,11 +120,15 @@ pub(crate) async fn process<C: ConnectionTrait>(
 }
 
 async fn verify(invocation: &TinyCloudInvocation) -> Result<(), Error> {
-    invocation
-        // TODO go back to static DID_METHODS
-        .verify_signature(&AnyDidMethod::default())
-        .await
-        .map_err(|_| InvocationError::InvalidSignature)?;
+    tokio::time::timeout(
+        DID_RESOLUTION_TIMEOUT,
+        invocation
+            // TODO go back to static DID_METHODS
+            .verify_signature(&AnyDidMethod::default()),
+    )
+    .await
+    .map_err(|_| InvocationError::InvalidSignature)?
+    .map_err(|_| InvocationError::InvalidSignature)?;
     invocation
         .payload()
         .validate_time(None)

--- a/tinycloud-core/src/models/invocation.rs
+++ b/tinycloud-core/src/models/invocation.rs
@@ -6,6 +6,7 @@ use super::super::{
     util,
 };
 use crate::encryption::ColumnEncryption;
+use crate::models::did_resolution::did_resolution_timeout;
 use crate::policy_capability::sql_caveat;
 use crate::types::{Caveats, Facts, Resource, SpaceIdWrap};
 use crate::write_hooks::{hook_delivery_id, subscription_matches_event};
@@ -15,14 +16,11 @@ use sea_orm::{
 };
 use serde::Serialize;
 use std::collections::HashMap;
-use std::time::Duration;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use tinycloud_auth::{
     authorization::TinyCloudInvocation, identity::did_principal_matches, resource::Path,
     ssi::dids::AnyDidMethod,
 };
-
-const DID_RESOLUTION_TIMEOUT: Duration = Duration::from_secs(3);
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "invocation")]
@@ -121,7 +119,7 @@ pub(crate) async fn process<C: ConnectionTrait>(
 
 async fn verify(invocation: &TinyCloudInvocation) -> Result<(), Error> {
     tokio::time::timeout(
-        DID_RESOLUTION_TIMEOUT,
+        did_resolution_timeout(),
         invocation
             // TODO go back to static DID_METHODS
             .verify_signature(&AnyDidMethod::default()),

--- a/tinycloud-core/src/models/mod.rs
+++ b/tinycloud-core/src/models/mod.rs
@@ -2,6 +2,7 @@ pub mod abilities;
 pub mod actor;
 pub mod database_artifact;
 pub mod delegation;
+pub(crate) mod did_resolution;
 pub mod encryption_audit;
 pub mod encryption_ceremony;
 pub mod encryption_network;

--- a/tinycloud-core/src/models/revocation.rs
+++ b/tinycloud-core/src/models/revocation.rs
@@ -1,5 +1,6 @@
 use super::super::{events::Revocation, models::*, relationships::*};
 use crate::hash::{hash, Hash};
+use crate::models::did_resolution::did_resolution_timeout;
 use sea_orm::{entity::prelude::*, sea_query::OnConflict, ConnectionTrait};
 use time::OffsetDateTime;
 use tinycloud_auth::{
@@ -89,9 +90,13 @@ pub(crate) async fn process<C: ConnectionTrait>(
             };
         }
         TinyCloudRevocation::Ucan(u) => {
-            u.verify_signature(&AnyDidMethod::default())
-                .await
-                .map_err(|_| RevocationError::InvalidSignature)?;
+            tokio::time::timeout(
+                did_resolution_timeout(),
+                u.verify_signature(&AnyDidMethod::default()),
+            )
+            .await
+            .map_err(|_| RevocationError::InvalidSignature)?
+            .map_err(|_| RevocationError::InvalidSignature)?;
             u.payload()
                 .validate_time(None)
                 .map_err(|_| RevocationError::InvalidTime)?;

--- a/tinycloud-core/src/policy_capability/mod.rs
+++ b/tinycloud-core/src/policy_capability/mod.rs
@@ -39,6 +39,7 @@ pub fn accepted_actions(service: &str) -> Option<&'static [&'static str]> {
         "tinycloud.sql" => Some(&[
             "tinycloud.sql/read",
             "tinycloud.sql/select",
+            "tinycloud.sql/schema",
             "tinycloud.sql/write",
         ]),
         "tinycloud.vfs" => Some(&[
@@ -409,19 +410,15 @@ pub struct ResolvedAuthority {
 mod tests {
     use super::*;
 
-    const CANON_VECTORS: &str = include_str!(
-        "../../tests/fixtures/w1/policy-capability/canonicalization-vectors.json"
-    );
-    const CONTAINMENT_VECTORS: &str = include_str!(
-        "../../tests/fixtures/w1/policy-capability/containment-vectors.json"
-    );
-    const REJECTION_VECTORS: &str = include_str!(
-        "../../tests/fixtures/w1/policy-capability/rejection-vectors.json"
-    );
+    const CANON_VECTORS: &str =
+        include_str!("../../tests/fixtures/w1/policy-capability/canonicalization-vectors.json");
+    const CONTAINMENT_VECTORS: &str =
+        include_str!("../../tests/fixtures/w1/policy-capability/containment-vectors.json");
+    const REJECTION_VECTORS: &str =
+        include_str!("../../tests/fixtures/w1/policy-capability/rejection-vectors.json");
     const SQL_CONTAINMENT_VECTORS: &str =
         include_str!("../../tests/fixtures/w1/sql-caveat/containment.json");
-    const SQL_REJECT_VECTORS: &str =
-        include_str!("../../tests/fixtures/w1/sql-caveat/reject.json");
+    const SQL_REJECT_VECTORS: &str = include_str!("../../tests/fixtures/w1/sql-caveat/reject.json");
 
     #[derive(Deserialize)]
     struct CanonVector {

--- a/tinycloud-core/src/sql/authorizer.rs
+++ b/tinycloud-core/src/sql/authorizer.rs
@@ -27,6 +27,7 @@ pub fn create_authorizer(
     ability: String,
     is_admin: bool,
 ) -> impl FnMut(AuthContext<'_>) -> Authorization {
+    let mut schema_ddl_authorized = false;
     move |ctx: AuthContext<'_>| match ctx.action {
         // Always deny attach/detach
         AuthAction::Attach { .. } | AuthAction::Detach { .. } => Authorization::Deny,
@@ -164,6 +165,13 @@ pub fn create_authorizer(
             table_name,
             column_name,
         } => {
+            if !is_admin
+                && matches!(ability.as_str(), "tinycloud.sql/schema")
+                && !schema_ddl_authorized
+                && !is_sqlite_schema_table(table_name)
+            {
+                return Authorization::Deny;
+            }
             if let Some(ref caveats) = caveats {
                 if !caveats.is_table_allowed(table_name) {
                     return Authorization::Deny;
@@ -243,12 +251,21 @@ pub fn create_authorizer(
             {
                 Authorization::Deny
             } else {
+                if !is_admin && matches!(ability.as_str(), "tinycloud.sql/schema") {
+                    schema_ddl_authorized = true;
+                }
                 Authorization::Allow
             }
         }
 
         // Allow internal operations
         AuthAction::Transaction { .. } | AuthAction::Savepoint { .. } | AuthAction::Select => {
+            if !is_admin
+                && matches!(ability.as_str(), "tinycloud.sql/schema")
+                && !schema_ddl_authorized
+            {
+                return Authorization::Deny;
+            }
             Authorization::Allow
         }
 
@@ -386,6 +403,32 @@ mod tests {
                 }
             ),
             Authorization::Deny
+        );
+    }
+
+    #[test]
+    fn schema_ability_denies_application_table_reads() {
+        assert_eq!(
+            authorize(
+                "tinycloud.sql/schema",
+                false,
+                AuthAction::Read {
+                    table_name: "interaction",
+                    column_name: "nonce",
+                }
+            ),
+            Authorization::Deny
+        );
+        assert_eq!(
+            authorize(
+                "tinycloud.sql/schema",
+                false,
+                AuthAction::Read {
+                    table_name: "sqlite_schema",
+                    column_name: "sql",
+                }
+            ),
+            Authorization::Allow
         );
     }
 

--- a/tinycloud-core/src/sql/authorizer.rs
+++ b/tinycloud-core/src/sql/authorizer.rs
@@ -2,6 +2,26 @@ use rusqlite::hooks::{AuthAction, AuthContext, Authorization};
 
 use super::caveats::SqlCaveats;
 
+fn can_write_data(ability: &str, is_admin: bool) -> bool {
+    is_admin
+        || matches!(
+            ability,
+            "tinycloud.sql/admin" | "tinycloud.sql/write" | "tinycloud.sql/*"
+        )
+}
+
+fn is_sqlite_schema_table(table_name: &str) -> bool {
+    matches!(
+        table_name,
+        "sqlite_master" | "sqlite_schema" | "sqlite_temp_master" | "sqlite_temp_schema"
+    )
+}
+
+fn can_write_table(ability: &str, is_admin: bool, table_name: &str) -> bool {
+    can_write_data(ability, is_admin)
+        || (ability == "tinycloud.sql/schema" && is_sqlite_schema_table(table_name))
+}
+
 pub fn create_authorizer(
     caveats: Option<SqlCaveats>,
     ability: String,
@@ -157,10 +177,7 @@ pub fn create_authorizer(
 
         // Write operations
         AuthAction::Insert { table_name } | AuthAction::Delete { table_name } => {
-            if matches!(
-                ability.as_str(),
-                "tinycloud.sql/read" | "tinycloud.sql/select"
-            ) {
+            if !can_write_table(ability.as_str(), is_admin, table_name) {
                 return Authorization::Deny;
             }
             if let Some(ref caveats) = caveats {
@@ -178,10 +195,7 @@ pub fn create_authorizer(
             table_name,
             column_name,
         } => {
-            if matches!(
-                ability.as_str(),
-                "tinycloud.sql/read" | "tinycloud.sql/select"
-            ) {
+            if !can_write_table(ability.as_str(), is_admin, table_name) {
                 return Authorization::Deny;
             }
             if let Some(ref caveats) = caveats {
@@ -279,6 +293,26 @@ mod tests {
     }
 
     #[test]
+    fn create_index_allowed_with_schema_ability() {
+        let create_index = AuthAction::CreateIndex {
+            index_name: "uq_interaction_nonce",
+            table_name: "interaction",
+        };
+        let reindex = AuthAction::Reindex {
+            index_name: "uq_interaction_nonce",
+        };
+
+        assert_eq!(
+            authorize("tinycloud.sql/schema", false, create_index),
+            Authorization::Allow
+        );
+        assert_eq!(
+            authorize("tinycloud.sql/schema", false, reindex),
+            Authorization::Allow
+        );
+    }
+
+    #[test]
     fn create_index_allowed_for_admin() {
         let create_index = AuthAction::CreateIndex {
             index_name: "uq_interaction_nonce",
@@ -320,6 +354,41 @@ mod tests {
         );
     }
 
+    #[test]
+    fn schema_ability_denies_dml() {
+        assert_eq!(
+            authorize(
+                "tinycloud.sql/schema",
+                false,
+                AuthAction::Insert {
+                    table_name: "interaction"
+                }
+            ),
+            Authorization::Deny
+        );
+        assert_eq!(
+            authorize(
+                "tinycloud.sql/schema",
+                false,
+                AuthAction::Delete {
+                    table_name: "interaction"
+                }
+            ),
+            Authorization::Deny
+        );
+        assert_eq!(
+            authorize(
+                "tinycloud.sql/schema",
+                false,
+                AuthAction::Update {
+                    table_name: "interaction",
+                    column_name: "nonce",
+                }
+            ),
+            Authorization::Deny
+        );
+    }
+
     /// Install the authorizer on a real rusqlite connection (mirroring the
     /// wiring in database.rs) and run `sql` under the given cap.
     fn execute_under_authorizer(
@@ -355,6 +424,26 @@ mod tests {
             "CREATE UNIQUE INDEX uq_interaction_nonce ON interaction (reader_did, nonce)",
         )
         .expect("CREATE UNIQUE INDEX should succeed with a write cap");
+    }
+
+    #[test]
+    fn create_unique_index_executes_with_schema_cap() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        execute_under_authorizer(
+            &conn,
+            "tinycloud.sql/schema",
+            false,
+            "CREATE TABLE interaction (reader_did TEXT, nonce TEXT)",
+        )
+        .unwrap();
+
+        execute_under_authorizer(
+            &conn,
+            "tinycloud.sql/schema",
+            false,
+            "CREATE UNIQUE INDEX uq_interaction_nonce ON interaction (reader_did, nonce)",
+        )
+        .expect("CREATE UNIQUE INDEX should succeed with a schema cap");
     }
 
     #[test]

--- a/tinycloud-core/src/sql/parser.rs
+++ b/tinycloud-core/src/sql/parser.rs
@@ -81,6 +81,7 @@ pub fn validate_sql(
                 }
             }
             Statement::CreateTable { .. }
+            | Statement::CreateView { .. }
             | Statement::AlterTable { .. }
             | Statement::Drop { .. }
             | Statement::CreateIndex { .. } => {
@@ -116,7 +117,13 @@ pub fn validate_sql(
         )
     {
         return Err(SqlError::PermissionDenied(
-            "Schema operations require admin, write, or schema ability".to_string(),
+            "DDL operations require admin, schema, or write ability".to_string(),
+        ));
+    }
+
+    if !is_read_only && !is_ddl && matches!(ability, "tinycloud.sql/schema") {
+        return Err(SqlError::PermissionDenied(
+            "DML operations require write ability".to_string(),
         ));
     }
 
@@ -220,6 +227,9 @@ fn extract_tables_from_statement(stmt: &Statement, tables: &mut Vec<String>) {
         Statement::CreateTable { name, .. } => {
             tables.push(name.to_string());
         }
+        Statement::CreateView { name, .. } => {
+            tables.push(name.to_string());
+        }
         Statement::AlterTable { name, .. } => {
             tables.push(name.to_string());
         }
@@ -315,6 +325,9 @@ pub fn extract_write_targets_from_statement(stmt: &Statement) -> Option<TouchedT
         Statement::Update { table, .. } => extract_write_target_from_update(table),
         Statement::Delete { tables, from, .. } => extract_write_target_from_delete(tables, from),
         Statement::CreateTable { name, .. } | Statement::AlterTable { name, .. } => {
+            Some(TouchedTables::supported(vec![name.to_string()]))
+        }
+        Statement::CreateView { name, .. } => {
             Some(TouchedTables::supported(vec![name.to_string()]))
         }
         Statement::Drop { names, .. } => Some(TouchedTables::supported(unique_names(
@@ -422,19 +435,6 @@ mod tests {
     }
 
     #[test]
-    fn validate_sql_allows_schema_ability_for_schema_changes() {
-        let parsed = validate_sql(
-            "CREATE TABLE IF NOT EXISTS notes (id INTEGER PRIMARY KEY, body TEXT)",
-            &None,
-            "tinycloud.sql/schema",
-        )
-        .expect("schema ability should allow schema changes");
-
-        assert!(parsed.is_ddl);
-        assert!(!parsed.is_read_only);
-    }
-
-    #[test]
     fn validate_sql_rejects_ddl_ability_for_schema_changes() {
         let err = validate_sql(
             "CREATE TABLE IF NOT EXISTS notes (id INTEGER PRIMARY KEY, body TEXT)",
@@ -444,5 +444,57 @@ mod tests {
         .expect_err("ddl ability is not a schema permission");
 
         assert!(matches!(err, SqlError::PermissionDenied(_)));
+    }
+
+    #[test]
+    fn schema_ability_allows_ddl() {
+        let parsed = validate_sql(
+            "CREATE TABLE IF NOT EXISTS conversation (id TEXT PRIMARY KEY)",
+            &None,
+            "tinycloud.sql/schema",
+        )
+        .expect("schema ability should authorize DDL");
+
+        assert!(parsed.is_ddl);
+        assert!(!parsed.is_read_only);
+        assert_eq!(
+            parsed.write_targets,
+            vec![TouchedTables::supported(vec!["conversation".to_string()])]
+        );
+    }
+
+    #[test]
+    fn schema_ability_rejects_dml() {
+        for sql in [
+            "INSERT INTO conversation (id) VALUES ('1')",
+            "UPDATE conversation SET id = '2'",
+            "DELETE FROM conversation WHERE id = '1'",
+        ] {
+            let err = validate_sql(sql, &None, "tinycloud.sql/schema")
+                .expect_err("schema ability must not authorize DML");
+
+            assert!(
+                matches!(err, SqlError::PermissionDenied(ref message) if message.contains("write ability")),
+                "expected DML permission denial for {sql}, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn schema_ability_allows_create_view() {
+        let parsed = validate_sql(
+            "CREATE VIEW conversation_ids AS SELECT id FROM conversation",
+            &None,
+            "tinycloud.sql/schema",
+        )
+        .expect("schema ability should authorize CREATE VIEW");
+
+        assert!(parsed.is_ddl);
+        assert_eq!(
+            parsed.write_targets,
+            vec![TouchedTables::supported(vec![
+                "conversation_ids".to_string()
+            ])]
+        );
     }
 }

--- a/tinycloud-core/src/sql/parser.rs
+++ b/tinycloud-core/src/sql/parser.rs
@@ -51,14 +51,17 @@ pub fn validate_sql(
     let mut write_targets = Vec::new();
     let mut is_read_only = true;
     let mut is_ddl = false;
+    let mut has_non_ddl = false;
 
     for stmt in &statements {
         match stmt {
             Statement::Query(_) => {
+                has_non_ddl = true;
                 extract_tables_from_statement(stmt, &mut tables);
                 extract_columns_from_statement(stmt, &mut columns);
             }
             Statement::Insert { .. } => {
+                has_non_ddl = true;
                 is_read_only = false;
                 extract_tables_from_statement(stmt, &mut tables);
                 if let Some(targets) = extract_write_targets_from_statement(stmt) {
@@ -66,6 +69,7 @@ pub fn validate_sql(
                 }
             }
             Statement::Update { .. } => {
+                has_non_ddl = true;
                 is_read_only = false;
                 extract_tables_from_statement(stmt, &mut tables);
                 extract_columns_from_statement(stmt, &mut columns);
@@ -74,6 +78,7 @@ pub fn validate_sql(
                 }
             }
             Statement::Delete { .. } => {
+                has_non_ddl = true;
                 is_read_only = false;
                 extract_tables_from_statement(stmt, &mut tables);
                 if let Some(targets) = extract_write_targets_from_statement(stmt) {
@@ -121,7 +126,7 @@ pub fn validate_sql(
         ));
     }
 
-    if !is_ddl && matches!(ability, "tinycloud.sql/schema") {
+    if matches!(ability, "tinycloud.sql/schema") && (!is_ddl || has_non_ddl) {
         return Err(SqlError::PermissionDenied(
             "Schema ability only permits DDL operations".to_string(),
         ));
@@ -488,6 +493,21 @@ mod tests {
         assert!(
             matches!(err, SqlError::PermissionDenied(ref message) if message.contains("only permits DDL")),
             "expected SELECT permission denial, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn schema_ability_rejects_mixed_ddl_and_select() {
+        let err = validate_sql(
+            "CREATE TABLE conversation (id TEXT); SELECT id FROM private_conversation",
+            &None,
+            "tinycloud.sql/schema",
+        )
+        .expect_err("schema ability must not authorize mixed DDL and reads");
+
+        assert!(
+            matches!(err, SqlError::PermissionDenied(ref message) if message.contains("only permits DDL")),
+            "expected mixed-statement permission denial, got {err:?}"
         );
     }
 

--- a/tinycloud-core/src/sql/parser.rs
+++ b/tinycloud-core/src/sql/parser.rs
@@ -121,9 +121,9 @@ pub fn validate_sql(
         ));
     }
 
-    if !is_read_only && !is_ddl && matches!(ability, "tinycloud.sql/schema") {
+    if !is_ddl && matches!(ability, "tinycloud.sql/schema") {
         return Err(SqlError::PermissionDenied(
-            "DML operations require write ability".to_string(),
+            "Schema ability only permits DDL operations".to_string(),
         ));
     }
 
@@ -474,10 +474,21 @@ mod tests {
                 .expect_err("schema ability must not authorize DML");
 
             assert!(
-                matches!(err, SqlError::PermissionDenied(ref message) if message.contains("write ability")),
+                matches!(err, SqlError::PermissionDenied(ref message) if message.contains("only permits DDL")),
                 "expected DML permission denial for {sql}, got {err:?}"
             );
         }
+    }
+
+    #[test]
+    fn schema_ability_rejects_select() {
+        let err = validate_sql("SELECT id FROM conversation", &None, "tinycloud.sql/schema")
+            .expect_err("schema ability must not authorize reads");
+
+        assert!(
+            matches!(err, SqlError::PermissionDenied(ref message) if message.contains("only permits DDL")),
+            "expected SELECT permission denial, got {err:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- wrap UCAN invocation/delegation/revocation signature verification in a configurable timeout to avoid stalled did:web resolution
- default DID resolution timeout is 3000 ms; override with `TINYCLOUD_DID_RESOLUTION_TIMEOUT_MS`
- allow `tinycloud.sql/schema` as a policy capability action and SQL DDL grant
- keep schema grants DDL-only: parser rejects SELECT/DML and mixed DDL+non-DDL batches, authorizer denies standalone schema reads/DML while allowing SQLite internal reads needed for DDL
- keep schema grants from authorizing application-table DML, while allowing SQLite internal schema-table writes required by DDL

## Tests
- `cargo fmt --check`
- `cargo test -p tinycloud-core models::did_resolution`
- `cargo test -p tinycloud-core sql::parser`
- `cargo test -p tinycloud-core sql::authorizer`
- `cargo test -p tinycloud-core policy_capability`
