### PR TITLE
fix: distinguish epoch-insert DB errors from missing spaces

### DIFF
--- a/tinycloud-core/src/db.rs
+++ b/tinycloud-core/src/db.rs
@@ -98,6 +98,8 @@ pub enum TxError<S: StorageSetup, K: Secrets> {
     Secrets(K::Error),
     #[error("Space not found")]
     SpaceNotFound,
+    #[error("epoch insert failed: {0}")]
+    EpochInsert(DbErr),
     #[error("Invalid delegation CID: {0}")]
     InvalidCid(String),
     #[error("encryption error: {0}")]
@@ -897,6 +899,33 @@ pub(crate) async fn transact<C: ConnectionTrait, S: StorageSetup, K: Secrets>(
 
         (filtered, skipped)
     } else {
+        // Non-delegation-only txns must reference spaces that already exist
+        // (or are created in this same txn via `new_spaces`). A missing space
+        // is a genuine SpaceNotFound (404); checking up-front lets an FK
+        // violation on the epoch insert be treated as an integrity error (500)
+        // rather than silently coerced to 404.
+        let new_space_ids: HashSet<SpaceId> = new_spaces.iter().map(|s| s.0.clone()).collect();
+        let to_check: Vec<SpaceIdWrap> = event_spaces
+            .keys()
+            .filter(|s| !new_space_ids.contains(s))
+            .cloned()
+            .map(SpaceIdWrap)
+            .collect();
+        if !to_check.is_empty() {
+            let existing: HashSet<SpaceId> = space::Entity::find()
+                .filter(space::Column::Id.is_in(to_check))
+                .all(db)
+                .await?
+                .into_iter()
+                .map(|s| s.id.0)
+                .collect();
+            if event_spaces
+                .keys()
+                .any(|s| !new_space_ids.contains(s) && !existing.contains(s))
+            {
+                return Err(TxError::SpaceNotFound);
+            }
+        }
         (event_spaces, vec![])
     };
 
@@ -1016,17 +1045,20 @@ pub(crate) async fn transact<C: ConnectionTrait, S: StorageSetup, K: Secrets>(
         epoch::Entity::insert_many(epochs)
             .exec(db)
             .await
-            .map_err(|e| match e {
-                DbErr::Exec(RuntimeErr::SqlxError(SqlxError::Database(ref db_err))) => {
-                    tracing::warn!(
+            .map_err(|e| {
+                if let DbErr::Exec(RuntimeErr::SqlxError(SqlxError::Database(db_err))) = &e {
+                    tracing::error!(
                         error = %e,
                         db_error = %db_err,
                         db_error_code = ?db_err.code(),
-                        "epoch insert failed with database error"
+                        db_error_kind = ?db_err.kind(),
+                        "epoch insert failed with database error after space pre-check; \
+                         treating as integrity error"
                     );
-                    TxError::SpaceNotFound
+                } else {
+                    tracing::error!(error = %e, "epoch insert failed");
                 }
-                _ => e.into(),
+                TxError::EpochInsert(e)
             })?;
 
         // save epoch orderings
@@ -1621,5 +1653,35 @@ mod test {
         let space = test_space_id("untouched");
         let db = get_db().await.unwrap().with_sql_sizes(SqlSizes::new());
         assert_eq!(db.store_size(&space).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn epoch_insert_for_missing_space_is_fk_violation() {
+        let db = get_db().await.unwrap();
+        let space = test_space_id("ghost");
+        // Insert an epoch row for a space that was never created. With SQLite
+        // foreign keys enforced (sqlx default), this must trip the epoch->space
+        // FK rather than silently succeed.
+        let err = epoch::Entity::insert(epoch::ActiveModel::from(epoch::Model {
+            seq: 0,
+            id: crate::hash::hash(b"ghost-epoch"),
+            space: SpaceIdWrap(space),
+        }))
+        .exec(&db.conn)
+        .await
+        .unwrap_err();
+
+        match err {
+            DbErr::Exec(RuntimeErr::SqlxError(SqlxError::Database(db_err))) => {
+                assert_eq!(
+                    db_err.kind(),
+                    sea_orm::sqlx::error::ErrorKind::ForeignKeyViolation,
+                    "expected a foreign-key violation, got kind {:?} (code {:?})",
+                    db_err.kind(),
+                    db_err.code()
+                );
+            }
+            other => panic!("expected FK database error, got {other:?}"),
+        }
     }
 }

--- a/tinycloud-node-server/src/routes/mod.rs
+++ b/tinycloud-node-server/src/routes/mod.rs
@@ -232,6 +232,7 @@ pub async fn delegate(
                 (
                     match e {
                         TxError::SpaceNotFound => Status::NotFound,
+                        TxError::EpochInsert(_) => Status::InternalServerError,
                         TxError::Db(DbErr::ConnectionAcquire(_)) => Status::InternalServerError,
                         _ => Status::Unauthorized,
                     },
@@ -296,6 +297,7 @@ pub async fn revoke(
             (
                 match e {
                     TxError::SpaceNotFound => Status::NotFound,
+                    TxError::EpochInsert(_) => Status::InternalServerError,
                     TxError::Db(DbErr::ConnectionAcquire(_)) => Status::InternalServerError,
                     _ => Status::Forbidden,
                 },
@@ -960,6 +962,7 @@ async fn invoke_impl(
             Err(e) => Err((
                 match e {
                     TxStoreError::Tx(TxError::SpaceNotFound) => Status::NotFound,
+                    TxStoreError::Tx(TxError::EpochInsert(_)) => Status::InternalServerError,
                     TxStoreError::Tx(TxError::Db(DbErr::ConnectionAcquire(_))) => {
                         Status::InternalServerError
                     }
@@ -2188,6 +2191,7 @@ async fn verify_auth(
             (
                 match e {
                     TxStoreError::Tx(TxError::SpaceNotFound) => Status::NotFound,
+                    TxStoreError::Tx(TxError::EpochInsert(_)) => Status::InternalServerError,
                     TxStoreError::Tx(TxError::Db(DbErr::ConnectionAcquire(_))) => {
                         Status::InternalServerError
                     }


### PR DESCRIPTION
## Problem

`tinycloud-core/src/db.rs` mapped **any** DB error on the epoch insert in `transact` to `TxError::SpaceNotFound`, so genuine database failures (FK violations, I/O errors, constraint issues) surfaced to clients as `404 - Space not found`. This masked real server-side errors and made client bugs (like web-sdk's `spaces.create()` issuing a bare invocation for an unregistered space) nearly impossible to diagnose.

## Fix

- Non-delegation-only transactions now **pre-check space existence**: a genuinely missing space returns a deterministic 404.
- Any DB error on the epoch insert itself becomes `TxError::EpochInsert(DbErr)` → **500**, with an `error!` log carrying the SQLite code and kind.
- 4 new match arms in `tinycloud-node-server/src/routes/mod.rs` route the new variant.

## Behavior change

Clients that previously received a 404 for real epoch-insert DB errors now receive a 500 (with server-side logging). Only clients hitting genuine DB failures see the change; the missing-space 404 contract is unchanged (and now deterministic).

## Verification

- Unit test `epoch_insert_for_missing_space_is_fk_violation` proves FK enforcement and the error shape.
- Clippy `-D warnings` clean.
- Deterministic regression gate: 20/20 pre-commit.

## Independence from PR #89

This PR is **orthogonal to #89 (SQL metering)** — metering touches neither `transact` nor `TxError`. Verified; the two merge independently in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)