### PR TITLE
[Data Exchange One-Ticket Proof] W5 e2e: fresh nonce for post-revocation invocation

### DIFF
--- a/test/w5-policy-runtime-node-e2e/tests/challenge_to_native_read.rs
+++ b/test/w5-policy-runtime-node-e2e/tests/challenge_to_native_read.rs
@@ -235,7 +235,6 @@ secret = "{}"
     let constrained_caveat = policy_capability(&space_id)
         .caveats
         .context("policy capability must carry SQL caveat")?;
-    let mut invocation_caps = Capabilities::new();
     let mut invocation_nb = std::collections::BTreeMap::new();
     for (key, value) in constrained_caveat
         .as_object()
@@ -243,24 +242,28 @@ secret = "{}"
     {
         invocation_nb.insert(key.clone(), value.clone());
     }
-    invocation_caps.with_action(
-        sql_resource.as_uri(),
-        "tinycloud.sql/read".parse::<UcanAbility>()?,
-        [invocation_nb],
-    );
     let parent_cid: AuthCid = delegation_hash.to_cid(0x55);
-    let invocation = Payload {
-        issuer: holder_verification_method.parse::<DIDURLBuf>()?,
-        audience: holder_did.parse::<DIDBuf>()?,
-        not_before: None,
-        expiration: NumericDate::try_from_seconds(4_102_444_800.0)?,
-        nonce: Some("urn:uuid:00000000-0000-4000-8000-0000000000w5".to_string()),
-        facts: Some(Vec::<serde_json::Value>::new()),
-        proof: vec![parent_cid],
-        attenuation: invocation_caps,
-    }
-    .sign(holder_jwk.get_algorithm().unwrap_or_default(), &holder_jwk)?;
-    let auth_header = invocation.encode()?;
+    let make_auth_header = |nonce: &str| -> Result<String> {
+        let mut invocation_caps = Capabilities::new();
+        invocation_caps.with_action(
+            sql_resource.as_uri(),
+            "tinycloud.sql/read".parse::<UcanAbility>()?,
+            [invocation_nb.clone()],
+        );
+        let invocation = Payload {
+            issuer: holder_verification_method.parse::<DIDURLBuf>()?,
+            audience: holder_did.parse::<DIDBuf>()?,
+            not_before: None,
+            expiration: NumericDate::try_from_seconds(4_102_444_800.0)?,
+            nonce: Some(nonce.to_string()),
+            facts: Some(Vec::<serde_json::Value>::new()),
+            proof: vec![parent_cid],
+            attenuation: invocation_caps,
+        }
+        .sign(holder_jwk.get_algorithm().unwrap_or_default(), &holder_jwk)?;
+        Ok(invocation.encode()?)
+    };
+    let auth_header = make_auth_header("urn:uuid:00000000-0000-4000-8000-0000000000w5")?;
 
     let client = Client::tracked(rocket).await?;
     let response = client
@@ -298,6 +301,7 @@ secret = "{}"
     .insert(&conn)
     .await?;
 
+    let auth_header = make_auth_header("urn:uuid:00000000-0000-4000-8000-0000000000w6")?;
     let response = client
         .post("/invoke")
         .header(Header::new("Authorization", auth_header.clone()))


### PR DESCRIPTION
**Draft PR opened solely to trigger CI for the Data Exchange v0 One-Ticket Proof** (constrained Smithers execute run \`1eac7ee2\`, ticket \`proof-w5-e2e-fresh-nonce\`; operator-approved \`canMutateProduct\` + \`allowPush\`, 2026-07-02).

Test-only change: the excluded W5 e2e crate replayed the pre-revocation nonce on the post-revocation \`/invoke\`, so replay defense fired before revocation enforcement. The post-revocation request now signs a fresh nonce, so the observed 401 certifies revocation denial — matching the tracked W5 server test.

Verified in the run: \`cargo fmt\` (crate manifest), the e2e crate test (1 passed), the tracked \`w5_runtime_terminal_delegation_allows_native_read_then_cutoff_denies\` test, and the full repo verify chain (build + clippy \`-Dwarnings\` + tests) re-run post-merge on this branch.

Promotion to \`main\` is a separate human decision at the milestone gate — do not merge on the proof's account alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)