### PR TITLE
Publish an SSH TCP forwarder so the dstack gateway can route to guest sshd

### DIFF
--- a/docker-compose.dstack-postgres.yaml
+++ b/docker-compose.dstack-postgres.yaml
@@ -50,5 +50,19 @@ services:
       - cert-data:/etc/letsencrypt
     restart: unless-stopped
 
+  # The dstack gateway's TLS-terminating routes (<app>-<port>.<domain>:443)
+  # only forward to compose-published ports, so guest sshd on :22 is
+  # unreachable via `phala ssh` even with authorized_keys installed.
+  # Publish a TCP forwarder on 10022 that relays to guest sshd via the
+  # docker host gateway. Port 10022 exposes ONLY sshd, which is key-gated.
+  ssh-gateway:
+    image: alpine/socat:1.8.1.3@sha256:188fe0a22182f81c16def9d1137930121eaa3023f427164e32c0d2f118f79dd6
+    restart: unless-stopped
+    ports:
+      - "10022:10022"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: TCP-LISTEN:10022,fork,reuseaddr TCP:host.docker.internal:22
+
 volumes:
   cert-data:


### PR DESCRIPTION
## Why

Follow-up to #94 for the 1.4.3 quota release: the post-deploy usage audit needs shell access to the prod CVM. #94 installed the authorized key successfully — the serial log confirms `Root authorized_keys set` and `sshd.socket` is listening — but `phala ssh` still fails.

**Finding:** the dstack gateway's TLS-terminating routes (`<app>-<port>.<domain>:443`) only forward to compose-**published** ports, and guest sshd on :22 is not a compose port. Evidence:

- `<app>-8000` → serves `/info` (published port, routed)
- `<app>-443` → holds connections (published port, routed)
- `<app>-22` → instantly closes (terminating route, port not published → unrouted)
- `<app>-22s` → returns the raw `SSH-2` banner (passthrough route reaches the guest directly — sshd is alive on `0.0.0.0:22`)

So sshd is up and key-gated; it's the terminating routing path that can't see it.

## What

One new compose service, `ssh-gateway`: `alpine/socat` publishing `10022` and relaying to guest sshd via the docker host gateway:

```yaml
  ssh-gateway:
    image: alpine/socat:1.8.1.3@sha256:188fe0a22182f81c16def9d1137930121eaa3023f427164e32c0d2f118f79dd6
    restart: unless-stopped
    ports:
      - "10022:10022"
    extra_hosts:
      - "host.docker.internal:host-gateway"
    command: TCP-LISTEN:10022,fork,reuseaddr TCP:host.docker.internal:22
```

- Image pinned by tag+digest (no floating `latest`); verified multi-arch manifest includes **linux/amd64** and the image `ENTRYPOINT` is `socat` (so `command:` supplies the socat address args). Compose file validates with `docker compose config`.
- With 10022 published, the gateway routes `<app>-10022.<domain>:443`, enabling e.g.:
  ```
  ssh root@<app> -o ProxyCommand='openssl s_client -quiet -connect <app>-10022.dstack-pha-prod5.phala.network:443'
  ```

## Security

Port 10022 exposes **only** guest sshd, which is key-gated: `authorized_keys` is provisioned via `DSTACK_AUTHORIZED_KEYS` (#94) and the root password is randomly generated by the pre-launch script. No app or data surface is added.

## Deploy

Takes effect on the next `deploy-phala` run (compose update on CVM `tinycloud-node`). No env/secret changes needed.