### PR TITLE
Add admin GET /admin/usage aggregate space usage endpoint (TC-108)

### DIFF
--- a/tinycloud-core/src/db.rs
+++ b/tinycloud-core/src/db.rs
@@ -189,6 +189,18 @@ impl<C, B, K> SpaceDatabase<C, B, K>
 where
     C: ConnectionTrait,
 {
+    /// List every space id known to this node (the full `space` table).
+    /// Used by the admin usage endpoint to enumerate spaces without touching
+    /// SQL directly.
+    pub async fn list_space_ids(&self) -> Result<Vec<SpaceId>, DbErr> {
+        Ok(space::Entity::find()
+            .all(&self.conn)
+            .await?
+            .into_iter()
+            .map(|s| s.id.0)
+            .collect())
+    }
+
     pub async fn list_due_webhook_deliveries(
         &self,
         limit: u64,
@@ -1653,6 +1665,30 @@ mod test {
         let space = test_space_id("untouched");
         let db = get_db().await.unwrap().with_sql_sizes(SqlSizes::new());
         assert_eq!(db.store_size(&space).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn list_space_ids_returns_all_created_spaces() {
+        let db = get_db().await.unwrap();
+        // Empty node → empty list.
+        assert!(db.list_space_ids().await.unwrap().is_empty());
+
+        let a = test_space_id("alpha");
+        let b = test_space_id("beta");
+        space::Entity::insert_many([
+            space::ActiveModel::from(space::Model {
+                id: SpaceIdWrap(a.clone()),
+            }),
+            space::ActiveModel::from(space::Model {
+                id: SpaceIdWrap(b.clone()),
+            }),
+        ])
+        .exec(&db.conn)
+        .await
+        .unwrap();
+
+        let listed: HashSet<SpaceId> = db.list_space_ids().await.unwrap().into_iter().collect();
+        assert_eq!(listed, HashSet::from([a, b]));
     }
 
     #[tokio::test]

--- a/tinycloud-node-server/src/lib.rs
+++ b/tinycloud-node-server/src/lib.rs
@@ -31,7 +31,7 @@ use hooks::HookRuntime;
 use invocation_replay::InvocationReplayCache;
 use quota::QuotaCache;
 use routes::{
-    admin::{delete_quota, get_quota, list_quotas, set_quota},
+    admin::{delete_quota, get_quota, get_usage, list_quotas, set_quota},
     attestation::attestation,
     create_signed_kv_url, delegate,
     encryption::{
@@ -145,6 +145,7 @@ pub async fn app(config: &Figment) -> Result<Rocket<Build>> {
         delete_quota,
         get_quota,
         list_quotas,
+        get_usage,
         create_encryption_network,
         get_encryption_network,
         encryption_well_known,

--- a/tinycloud-node-server/src/routes/admin.rs
+++ b/tinycloud-node-server/src/routes/admin.rs
@@ -61,6 +61,18 @@ pub struct QuotaListResponse {
     pub default_limit_bytes: Option<u64>,
 }
 
+#[derive(Serialize)]
+pub struct SpaceUsage {
+    pub space_id: String,
+    pub usage_bytes: Option<u64>,
+}
+
+#[derive(Serialize)]
+pub struct UsageResponse {
+    pub spaces: Vec<SpaceUsage>,
+    pub count: usize,
+}
+
 #[put("/admin/quota/<space_id>", data = "<body>")]
 pub async fn set_quota(
     _auth: AdminAuth,
@@ -138,4 +150,85 @@ pub async fn list_quotas(
         overrides,
         default_limit_bytes: quota_cache.default_limit().map(|l| l.as_u64()),
     })
+}
+
+/// Enumerate every space on the node with its authoritative metered usage
+/// (`store_size`: KV block bytes + SQL/DuckDB artifact bytes, per #89).
+/// Sorted by usage descending, with unknown (`null`) usage last. No
+/// pagination: with a few hundred spaces this is a single pass.
+#[get("/admin/usage")]
+pub async fn get_usage(
+    _auth: AdminAuth,
+    tinycloud: &State<TinyCloud>,
+) -> Result<Json<UsageResponse>, (Status, String)> {
+    let space_ids = tinycloud
+        .list_space_ids()
+        .await
+        .map_err(|e| (Status::InternalServerError, e.to_string()))?;
+
+    let mut spaces = Vec::with_capacity(space_ids.len());
+    for sid in space_ids {
+        let usage = tinycloud
+            .store_size(&sid)
+            .await
+            .map_err(|e| (Status::InternalServerError, e.to_string()))?;
+        spaces.push(SpaceUsage {
+            space_id: sid.to_string(),
+            usage_bytes: usage,
+        });
+    }
+
+    // Descending by usage; `None` (unknown) sorts last.
+    sort_usage_desc_nulls_last(&mut spaces);
+
+    let count = spaces.len();
+    Ok(Json(UsageResponse { spaces, count }))
+}
+
+/// Sort spaces by usage descending, with unknown (`None`) usage last.
+fn sort_usage_desc_nulls_last(spaces: &mut [SpaceUsage]) {
+    spaces.sort_by(|a, b| match (a.usage_bytes, b.usage_bytes) {
+        (Some(x), Some(y)) => y.cmp(&x),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => std::cmp::Ordering::Equal,
+    });
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn su(space_id: &str, usage_bytes: Option<u64>) -> SpaceUsage {
+        SpaceUsage {
+            space_id: space_id.to_string(),
+            usage_bytes,
+        }
+    }
+
+    #[tokio::test]
+    async fn sort_orders_desc_with_nulls_last() {
+        let mut spaces = vec![
+            su("a", Some(10)),
+            su("b", None),
+            su("c", Some(100)),
+            su("d", None),
+            su("e", Some(50)),
+        ];
+        sort_usage_desc_nulls_last(&mut spaces);
+        let order: Vec<(&str, Option<u64>)> = spaces
+            .iter()
+            .map(|s| (s.space_id.as_str(), s.usage_bytes))
+            .collect();
+        assert_eq!(
+            order,
+            vec![
+                ("c", Some(100)),
+                ("e", Some(50)),
+                ("a", Some(10)),
+                ("b", None),
+                ("d", None),
+            ]
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Adds an admin-gated `GET /admin/usage` endpoint that enumerates every space on the node and reports each space's authoritative metered usage. Powers the internal dashboard's new `/usage` view (Linear **TC-108**), replacing the manual SSH + sqlite audit from the quota deploy runbook.

Usage comes from the same `store_size` path the quota code uses — post-#89 this is KV block bytes folded with SQL/DuckDB artifact bytes.

Response shape:
```json
{"spaces": [{"space_id": "...", "usage_bytes": 12345}], "count": 1}
```
Sorted by `usage_bytes` descending, with unknown (`null`) usage last.

## Changes

- **tinycloud-core** (`db.rs`): new `SpaceDatabase::list_space_ids()` lists the full `space` table via the sea-orm storage layer (no raw SQL), with a test.
- **admin.rs**: `get_usage` handler reuses the existing `AdminAuth` bearer guard exactly as the other `/admin/quota` routes do. Sorting extracted to a unit-tested helper (`sort_usage_desc_nulls_last`).
- **lib.rs**: route mounted alongside the other `/admin` routes.

## Pagination

None — there are ~377 spaces today, so this is a single pass. Pagination can be added later if the space count grows enough to matter.

## Testing

`cargo fmt`, `cargo clippy -p tinycloud-core -p tinycloud-node --all-targets -- -D warnings`, and targeted tests all pass locally:
- `tinycloud-core` `db::test` (5 tests incl. new `list_space_ids_returns_all_created_spaces`, cribbed from the #89 `store_size` tests)
- `tinycloud-node` `routes::admin::test::sort_orders_desc_with_nulls_last`

## Deploy

This does **not** auto-deploy — no version bump. It ships with the next release, or via a manual `docker.yml` dispatch with `deploy_phala=true` (that pipeline is now working). It is intentionally kept off the 1.4.3 quota deploy image.