### PR TITLE
fix(w5-e2e): use a fresh nonce for the post-revocation invoke (TC-120)

### DIFF
--- a/test/w5-policy-runtime-node-e2e/tests/challenge_to_native_read.rs
+++ b/test/w5-policy-runtime-node-e2e/tests/challenge_to_native_read.rs
@@ -257,7 +257,7 @@ secret = "{}"
         nonce: Some("urn:uuid:00000000-0000-4000-8000-0000000000w5".to_string()),
         facts: Some(Vec::<serde_json::Value>::new()),
         proof: vec![parent_cid],
-        attenuation: invocation_caps,
+        attenuation: invocation_caps.clone(),
     }
     .sign(holder_jwk.get_algorithm().unwrap_or_default(), &holder_jwk)?;
     let auth_header = invocation.encode()?;
@@ -265,7 +265,7 @@ secret = "{}"
     let client = Client::tracked(rocket).await?;
     let response = client
         .post("/invoke")
-        .header(Header::new("Authorization", auth_header.clone()))
+        .header(Header::new("Authorization", auth_header))
         .header(ContentType::JSON)
         .body(serde_json::to_string(&SqlRequest::ExecuteStatement {
             name: "get_val".to_string(),
@@ -298,9 +298,25 @@ secret = "{}"
     .insert(&conn)
     .await?;
 
+    // The node's invocation replay guard rejects reused nonces, so the
+    // post-revocation dispatch must carry a fresh nonce; only the nonce
+    // differs from the first invocation.
+    let post_revocation_invocation = Payload {
+        issuer: holder_verification_method.parse::<DIDURLBuf>()?,
+        audience: holder_did.parse::<DIDBuf>()?,
+        not_before: None,
+        expiration: NumericDate::try_from_seconds(4_102_444_800.0)?,
+        nonce: Some("urn:uuid:00000000-0000-4000-8000-0000000001w5".to_string()),
+        facts: Some(Vec::<serde_json::Value>::new()),
+        proof: vec![parent_cid],
+        attenuation: invocation_caps,
+    }
+    .sign(holder_jwk.get_algorithm().unwrap_or_default(), &holder_jwk)?;
+    let post_revocation_auth_header = post_revocation_invocation.encode()?;
+
     let response = client
         .post("/invoke")
-        .header(Header::new("Authorization", auth_header.clone()))
+        .header(Header::new("Authorization", post_revocation_auth_header))
         .header(ContentType::JSON)
         .body(serde_json::to_string(&SqlRequest::ExecuteStatement {
             name: "get_val".to_string(),


### PR DESCRIPTION
## Bug

`test/w5-policy-runtime-node-e2e/tests/challenge_to_native_read.rs` signed ONE invocation with a fixed nonce (`urn:uuid:...0000000000w5`) and dispatched it twice: once for the native read, and again after revocation expecting `401 delegation-revoked`. The node's invocation replay guard (`invocation_replay.rs`, added in PR #81) rejects the second dispatch as `duplicate invocation` before the revocation cutoff is evaluated, so the test failed with the wrong error. This failed identically on clean main (found during TC-112's gate).

## Fix

Sign a fresh invocation for the post-revocation dispatch. It mirrors the first invocation exactly — only the nonce differs (`...0000000001w5`). The assertion is unchanged: the second dispatch must still return `401` with a `delegation-revoked` error body.

## Test

```
cargo test --manifest-path test/w5-policy-runtime-node-e2e/Cargo.toml

running 1 test
test challenge_resolve_issued_delegation_native_read_then_cutoff_denies ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.18s
```

Refs TC-120