### PR TITLE
feat(gen-capabilities): emit REGISTRY_SOURCE_GIT_SHA/REPO for the js-sdk sync anchor (TC-121)

### DIFF
--- a/generated/capabilities.ts
+++ b/generated/capabilities.ts
@@ -7,6 +7,15 @@
 export const REGISTRY_VERSION = 1 as const;
 export const REGISTRY_SOURCE_SHA256 = "3850f17a9771600b4a0f7bfa38ccaed8464f3ee391342f5d5b627276e614a8ff" as const;
 
+/** GitHub repository the registry lives in (TC-121; js-sdk sync anchor). */
+export const REGISTRY_SOURCE_REPO = "TinyCloudLabs/tinycloud-node" as const;
+/**
+ * Git commit the artifact was generated from. Authoritative when generated
+ * in CI (GITHUB_SHA); approximate when generated locally, where it names
+ * the parent of the commit that will contain this artifact.
+ */
+export const REGISTRY_SOURCE_GIT_SHA = "e9be8963aef608b2e7cd61df500c84a6104df62a" as const;
+
 export type CapabilityStatus = "active" | "deprecated-alias" | "reserved";
 
 export interface CapabilityEntry {

--- a/scripts/gen-capabilities.mjs
+++ b/scripts/gen-capabilities.mjs
@@ -8,6 +8,17 @@
 //
 // Run `node scripts/gen-capabilities.mjs` to regenerate, or with `--check` to
 // fail if the checked-in artifacts are stale (used by CI).
+//
+// TC-121: both artifacts also embed REGISTRY_SOURCE_GIT_SHA / REGISTRY_SOURCE_REPO
+// so js-sdk's capabilities-sync CI can fetch the matching capabilities.json from
+// raw.githubusercontent.com (a content sha256 is not fetchable). The sha is
+// GITHUB_SHA when set (CI is authoritative); otherwise `git rev-parse HEAD` at
+// gen time, which is approximate: it names the parent of the commit that will
+// eventually contain the regenerated artifact (the artifact cannot know its own
+// commit). Because the environment's sha differs from the committed artifact's
+// sha on every new commit, --check normalizes the REGISTRY_SOURCE_GIT_SHA value
+// out of both sides before comparing — everything else must match byte-exact.
+// Full regeneration (no --check) always writes the real current sha.
 
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
@@ -25,6 +36,29 @@ const TS_OUT = join(ROOT, "generated/capabilities.ts");
 const raw = readFileSync(REGISTRY_PATH, "utf8");
 const registry = JSON.parse(raw);
 const sourceHash = createHash("sha256").update(raw).digest("hex");
+
+// TC-121: git rev the artifacts were generated from (see header for semantics).
+const SOURCE_REPO = "TinyCloudLabs/tinycloud-node";
+function resolveSourceGitSha() {
+  const env = process.env.GITHUB_SHA;
+  if (env) {
+    if (!/^[0-9a-f]{40}$/.test(env)) {
+      throw new Error(`GITHUB_SHA is not a 40-char hex sha: ${env}`);
+    }
+    return env;
+  }
+  const res = spawnSync("git", ["rev-parse", "HEAD"], { cwd: ROOT, encoding: "utf8" });
+  if (res.error || res.status !== 0) {
+    const detail = res.error ? res.error.message : res.stderr;
+    throw new Error(`git rev-parse HEAD failed: ${detail}`);
+  }
+  const sha = res.stdout.trim();
+  if (!/^[0-9a-f]{40}$/.test(sha)) {
+    throw new Error(`unexpected git rev-parse HEAD output: ${sha}`);
+  }
+  return sha;
+}
+const sourceGitSha = resolveSourceGitSha();
 
 const caps = registry.capabilities;
 
@@ -122,6 +156,13 @@ function emitRust() {
   lines.push(`pub const REGISTRY_VERSION: u32 = ${registry.version};`);
   lines.push(`pub const REGISTRY_SOURCE_SHA256: &str = ${rustStr(sourceHash)};`);
   lines.push("");
+  lines.push("/// GitHub repository the registry lives in (TC-121; js-sdk sync anchor).");
+  lines.push(`pub const REGISTRY_SOURCE_REPO: &str = ${rustStr(SOURCE_REPO)};`);
+  lines.push("/// Git commit the artifact was generated from. Authoritative when generated");
+  lines.push("/// in CI (GITHUB_SHA); approximate when generated locally, where it names");
+  lines.push("/// the parent of the commit that will contain this artifact.");
+  lines.push(`pub const REGISTRY_SOURCE_GIT_SHA: &str = ${rustStr(sourceGitSha)};`);
+  lines.push("");
   lines.push("/// Every action URN accepted at the policy boundary for `service`");
   lines.push("/// (active, deprecated-alias, and reserved), sorted. `None` if the");
   lines.push("/// service is unknown to the registry.");
@@ -173,6 +214,15 @@ function emitTs() {
   lines.push("");
   lines.push(`export const REGISTRY_VERSION = ${registry.version} as const;`);
   lines.push(`export const REGISTRY_SOURCE_SHA256 = ${JSON.stringify(sourceHash)} as const;`);
+  lines.push("");
+  lines.push("/** GitHub repository the registry lives in (TC-121; js-sdk sync anchor). */");
+  lines.push(`export const REGISTRY_SOURCE_REPO = ${JSON.stringify(SOURCE_REPO)} as const;`);
+  lines.push("/**");
+  lines.push(" * Git commit the artifact was generated from. Authoritative when generated");
+  lines.push(" * in CI (GITHUB_SHA); approximate when generated locally, where it names");
+  lines.push(" * the parent of the commit that will contain this artifact.");
+  lines.push(" */");
+  lines.push(`export const REGISTRY_SOURCE_GIT_SHA = ${JSON.stringify(sourceGitSha)} as const;`);
   lines.push("");
   lines.push("export type CapabilityStatus = \"active\" | \"deprecated-alias\" | \"reserved\";");
   lines.push("");
@@ -249,6 +299,19 @@ function rustfmt(src) {
 const rust = rustfmt(emitRust());
 const ts = emitTs();
 
+// --check must not fail merely because the current environment's git sha
+// differs from the one embedded in the committed artifact (every CI run on a
+// new commit would otherwise report the artifacts stale). Normalize the
+// REGISTRY_SOURCE_GIT_SHA value out of both sides before comparing; every
+// other byte must still match exactly. A malformed committed sha does not
+// match the regex, so it is not normalized and --check fails as it should.
+function normalizeGitSha(s) {
+  return s.replace(
+    /(REGISTRY_SOURCE_GIT_SHA[^=\n]*= ")[0-9a-f]{40}(")/g,
+    "$1<git-sha>$2",
+  );
+}
+
 const check = process.argv.includes("--check");
 if (check) {
   let stale = false;
@@ -259,7 +322,7 @@ if (check) {
     } catch {
       got = "";
     }
-    if (got !== want) {
+    if (normalizeGitSha(got) !== normalizeGitSha(want)) {
       console.error(`stale generated artifact: ${path}`);
       stale = true;
     }

--- a/tinycloud-core/src/policy_capability/generated.rs
+++ b/tinycloud-core/src/policy_capability/generated.rs
@@ -8,6 +8,13 @@ pub const REGISTRY_VERSION: u32 = 1;
 pub const REGISTRY_SOURCE_SHA256: &str =
     "3850f17a9771600b4a0f7bfa38ccaed8464f3ee391342f5d5b627276e614a8ff";
 
+/// GitHub repository the registry lives in (TC-121; js-sdk sync anchor).
+pub const REGISTRY_SOURCE_REPO: &str = "TinyCloudLabs/tinycloud-node";
+/// Git commit the artifact was generated from. Authoritative when generated
+/// in CI (GITHUB_SHA); approximate when generated locally, where it names
+/// the parent of the commit that will contain this artifact.
+pub const REGISTRY_SOURCE_GIT_SHA: &str = "e9be8963aef608b2e7cd61df500c84a6104df62a";
+
 /// Every action URN accepted at the policy boundary for `service`
 /// (active, deprecated-alias, and reserved), sorted. `None` if the
 /// service is unknown to the registry.


### PR DESCRIPTION
## What

`scripts/gen-capabilities.mjs` now embeds two additional constants in both generated artifacts (`generated/capabilities.ts` and `tinycloud-core/src/policy_capability/generated.rs`):

- `REGISTRY_SOURCE_REPO` — `"TinyCloudLabs/tinycloud-node"`
- `REGISTRY_SOURCE_GIT_SHA` — the 40-char git commit the artifact was generated from

TS: exported consts (js-sdk's capabilities-sync workflow can grep `REGISTRY_SOURCE_GIT_SHA = "<sha>"`). Rust: pub consts.

## Why

The TS artifact is vendored byte-identical into js-sdk. Its capabilities-sync CI needs to know which tinycloud-node rev to fetch `capabilities.json` from for the diff, but the header today only carries a content sha256 — which raw.githubusercontent.com cannot fetch by — so js-sdk falls back to a hardcoded `FALLBACK_NODE_REV`. A git sha + repo in the artifact gives the workflow a real fetch anchor.

## Sha semantics (CI-time authority + parent-sha caveat)

- When `GITHUB_SHA` is set (CI), it is authoritative and used verbatim (validated as 40-char hex).
- Otherwise `git rev-parse HEAD` at gen time. This local value is inherently **approximate**: it names the *parent* of the commit that will eventually contain the regenerated artifact — the artifact cannot know its own future commit sha (chicken-and-egg). Documented in the script header and in doc comments on the consts themselves.

## --check normalization design

`--check` must not fail merely because the environment's current sha differs from the sha embedded in the committed artifact — otherwise every CI run on a new commit would report the artifacts stale. `--check` therefore normalizes the `REGISTRY_SOURCE_GIT_SHA` value (regex-replacing the 40-hex value on that const's line with a placeholder) on **both** sides before comparing; every other byte must still match exactly. A malformed committed sha does not match the regex, is not normalized, and fails `--check` as it should. Full regeneration (no `--check`) always writes the real current sha.

## Verification

- `node scripts/gen-capabilities.mjs --check` passes, including with a deliberately different `GITHUB_SHA` in the environment
- `--check` still exits 1 on a genuinely stale artifact (verified by mutating the TS artifact)
- `cargo test -p tinycloud-core policy_capability` — 9 passed (incl. `generated_module_matches_registry`, which needed no changes: it compares registry data, not the sha)
- `cargo fmt --check -p tinycloud-core` clean
- `cargo clippy -p tinycloud-core` clean

Refs TC-121, TC-112.