### PR TITLE
feat(policy-capability): wire capability registry into live invoke/delegate paths (TC-119)

### DIFF
--- a/test/w5-policy-runtime-node-e2e/Cargo.lock
+++ b/test/w5-policy-runtime-node-e2e/Cargo.lock
@@ -7151,7 +7151,7 @@ dependencies = [
 
 [[package]]
 name = "tinycloud-node"
-version = "1.4.2"
+version = "1.4.4"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/test/w5-policy-runtime-node-e2e/tests/tc119_registry_wire_paths.rs
+++ b/test/w5-policy-runtime-node-e2e/tests/tc119_registry_wire_paths.rs
@@ -1,0 +1,385 @@
+//! TC-119 live-wire proof: the capability registry's alias and implication
+//! semantics are enforced by the REAL `/invoke` path (not just the unit-level
+//! `policy_capability::ability_matches`).
+//!
+//! A single node boot (the process-global logger can only be initialized once)
+//! drives several holder-signed UCAN invocations that cite a root-authority
+//! delegation persisted directly as a node row. Each invocation exercises the
+//! exact chain-containment code changed in TC-119 (`models/invocation.rs`)
+//! plus, for KV, the dispatch alias resolution in `db.rs`.
+//!
+//! Positive cases prove a registry-declared alias / implication authorizes an
+//! invocation whose ability differs from the grant; negative controls prove
+//! the change is a strict, registry-BOUNDED widening (undeclared pairs are
+//! still rejected). We assert on the error body because the KV `/invoke` error
+//! mapping collapses to 401 for both "authorized but no such key" and
+//! "unauthorized" — the body ("No Such Key" vs "Unauthorized Action") is the
+//! chain-authorization boundary, and neither `kv/del`/`kv/get`/`kv/delete`
+//! reaches block-store I/O before the chain check runs.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use rocket::{
+    figment::providers::{Format, Serialized, Toml},
+    http::{ContentType, Header, Status},
+    local::asynchronous::Client,
+};
+use tempfile::TempDir;
+use tinycloud_auth::{
+    authorization::Cid as AuthCid,
+    resolver::DID_METHODS,
+    resource::{Path as AuthPath, ResourceId, Service, SpaceId},
+    siwe_recap::Ability as UcanAbility,
+    ssi::{
+        claims::jwt::NumericDate,
+        dids::{DIDBuf, DIDURLBuf},
+        jwk::{Algorithm, JWK},
+        ucan::Payload,
+    },
+    ucan_capabilities_object::Capabilities,
+};
+use tinycloud_core::{
+    hash::Hash,
+    models::{abilities, actor, space},
+    sea_orm::{ActiveModelTrait, ActiveValue::Set, ConnectOptions, Database, DatabaseConnection},
+    sql::{SqlRequest, SqlService, SqlValue},
+    types::{Ability, Caveats, Resource, SpaceIdWrap},
+};
+
+const FAR_FUTURE_SECONDS: f64 = 4_102_444_800.0; // 2100-01-01
+
+fn test_space_id(name: &str) -> SpaceId {
+    let jwk = JWK::generate_ed25519().unwrap();
+    let did: DIDBuf = DID_METHODS.generate(&jwk, "key").unwrap();
+    SpaceId::new(did, name.parse().unwrap())
+}
+
+fn holder_identity() -> Result<(JWK, String, String)> {
+    let mut jwk = JWK::generate_ed25519()?;
+    jwk.algorithm = Some(Algorithm::EdDSA);
+    let did = DID_METHODS.generate(&jwk, "key")?.to_string();
+    let fragment = did
+        .rsplit_once(':')
+        .context("missing did:key fragment")?
+        .1
+        .to_string();
+    let verification_method = format!("{did}#{fragment}");
+    Ok((jwk, did, verification_method))
+}
+
+/// Persist a root-authority delegation row + one ability row directly, the way
+/// the node would have after `delegation::process`. The delegator is the space
+/// owner (root authority for the resource), so the grant is self-authorizing.
+async fn persist_grant(
+    conn: &DatabaseConnection,
+    delegation_hash: Hash,
+    owner_did: &str,
+    holder_did: &str,
+    resource: &ResourceId,
+    ability: &str,
+) -> Result<()> {
+    tinycloud_core::models::delegation::ActiveModel {
+        id: Set(delegation_hash),
+        delegator: Set(owner_did.to_string()),
+        delegatee: Set(holder_did.to_string()),
+        expiry: Set(Some(time::OffsetDateTime::from_unix_timestamp(
+            FAR_FUTURE_SECONDS as i64,
+        )?)),
+        issued_at: Set(Some(time::OffsetDateTime::UNIX_EPOCH)),
+        not_before: Set(None),
+        facts: Set(None),
+        serialization: Set(format!("tc119-test-row:{ability}").into_bytes()),
+    }
+    .insert(conn)
+    .await?;
+
+    abilities::ActiveModel {
+        delegation: Set(delegation_hash),
+        resource: Set(Resource::TinyCloud(resource.clone())),
+        ability: Set(Ability::try_from(ability.to_string()).unwrap()),
+        caveats: Set(Caveats(BTreeMap::new())),
+    }
+    .insert(conn)
+    .await?;
+    Ok(())
+}
+
+/// Build a holder-signed UCAN invocation Authorization header citing
+/// `delegation_hash` as its proof and requesting `ability` on `resource`.
+fn holder_invocation(
+    holder_jwk: &JWK,
+    holder_did: &str,
+    holder_vm: &str,
+    delegation_hash: Hash,
+    resource: &ResourceId,
+    ability: &str,
+    nonce: &str,
+) -> Result<String> {
+    let mut caps = Capabilities::new();
+    caps.with_action(
+        resource.as_uri(),
+        ability.parse::<UcanAbility>()?,
+        [BTreeMap::<String, serde_json::Value>::new()],
+    );
+    let parent_cid: AuthCid = delegation_hash.to_cid(0x55);
+    let invocation = Payload {
+        issuer: holder_vm.parse::<DIDURLBuf>()?,
+        audience: holder_did.parse::<DIDBuf>()?,
+        not_before: None,
+        expiration: NumericDate::try_from_seconds(FAR_FUTURE_SECONDS)?,
+        nonce: Some(nonce.to_string()),
+        facts: Some(Vec::<serde_json::Value>::new()),
+        proof: vec![parent_cid],
+        attenuation: caps,
+    }
+    .sign(holder_jwk.get_algorithm().unwrap_or_default(), holder_jwk)?;
+    Ok(invocation.encode()?)
+}
+
+#[tokio::test]
+async fn registry_alias_and_implication_are_enforced_on_the_wire() -> Result<()> {
+    let tempdir = TempDir::new()?;
+    let datadir = tempdir.path().join("data");
+    let db_url = format!("sqlite:{}", datadir.join("caps.db").display());
+    let secret = URL_SAFE_NO_PAD.encode([9u8; 32]);
+    let config_overlay = format!(
+        r#"
+[storage]
+datadir = "{}"
+
+[keys]
+type = "Static"
+secret = "{}"
+"#,
+        datadir.display(),
+        secret
+    );
+    let figment = rocket::Config::figment()
+        .merge(Serialized::defaults(tinycloud::config::Config::default()))
+        .merge(Toml::string(&config_overlay));
+    let rocket = tinycloud::app(&figment).await?;
+    let sql_service = rocket
+        .state::<SqlService>()
+        .context("node app must manage SqlService")?;
+    let conn = Database::connect(ConnectOptions::new(db_url)).await?;
+
+    let space_id = test_space_id("tc119-wire");
+    let owner_did = space_id.did().to_string();
+    space::ActiveModel {
+        id: Set(SpaceIdWrap(space_id.clone())),
+    }
+    .insert(&conn)
+    .await?;
+
+    let (holder_jwk, holder_did, holder_vm) = holder_identity()?;
+    for did in [&owner_did, &holder_did] {
+        actor::ActiveModel {
+            id: Set(did.clone()),
+        }
+        .insert(&conn)
+        .await?;
+    }
+
+    // Materialize the SQL db so the holder's DDL has a database to run in.
+    sql_service
+        .execute(
+            &space_id,
+            "records",
+            SqlRequest::Execute {
+                schema: Some(vec!["CREATE TABLE seed (id INTEGER)".to_string()]),
+                sql: "INSERT INTO seed (id) VALUES (?)".to_string(),
+                params: vec![SqlValue::Integer(1)],
+            },
+            None,
+            "tinycloud.sql/write".to_string(),
+        )
+        .await?;
+
+    let kv_resource: ResourceId = space_id.clone().to_resource(
+        "kv".parse::<Service>()?,
+        Some("docs/note".parse::<AuthPath>()?),
+        None,
+        None,
+    );
+    let sql_resource: ResourceId = space_id.clone().to_resource(
+        "sql".parse::<Service>()?,
+        Some("records".parse::<AuthPath>()?),
+        None,
+        None,
+    );
+
+    // The holder is granted the DEPRECATED ALIAS `kv/delete` and only
+    // `sql/admin`.
+    let kv_del_grant = tinycloud_core::hash::hash(b"tc119-kv-delete-alias-grant");
+    persist_grant(
+        &conn,
+        kv_del_grant,
+        &owner_did,
+        &holder_did,
+        &kv_resource,
+        "tinycloud.kv/delete",
+    )
+    .await?;
+    let sql_admin_grant = tinycloud_core::hash::hash(b"tc119-sql-admin-grant");
+    persist_grant(
+        &conn,
+        sql_admin_grant,
+        &owner_did,
+        &holder_did,
+        &sql_resource,
+        "tinycloud.sql/admin",
+    )
+    .await?;
+
+    let client = Client::tracked(rocket).await?;
+
+    // Helper: dispatch a bodiless KV invocation and return (status, body).
+    async fn kv_invoke(client: &Client, header: String) -> (Status, String) {
+        let resp = client
+            .post("/invoke")
+            .header(Header::new("Authorization", header))
+            .dispatch()
+            .await;
+        let status = resp.status();
+        let body = resp.into_string().await.unwrap_or_default();
+        (status, body)
+    }
+
+    // --- KV: chain-level alias (grant `kv/delete` ⊇ request `kv/del`) ---
+    // A `kv/del` request authorized by the `kv/delete` grant clears the chain
+    // check and fails only at the (empty-store) delete lookup — proving the
+    // alias is honored on the chain. Pre-TC-119 this returned "Unauthorized
+    // Action".
+    let (_status, body) = kv_invoke(
+        &client,
+        holder_invocation(
+            &holder_jwk,
+            &holder_did,
+            &holder_vm,
+            kv_del_grant,
+            &kv_resource,
+            "tinycloud.kv/del",
+            "urn:uuid:00000000-0000-4000-8000-00000000c101",
+        )?,
+    )
+    .await;
+    assert!(
+        body.contains("No Such Key"),
+        "kv/delete grant must authorize a kv/del request on the chain \
+         (expected the empty-store 'No Such Key', got: {body})"
+    );
+    assert!(
+        !body.contains("Unauthorized Action"),
+        "kv/del must NOT be rejected by the chain check: {body}"
+    );
+
+    // --- KV: dispatch-level alias (request `kv/delete` dispatches as `del`) ---
+    // An invocation whose OWN ability is the alias `kv/delete` must dispatch to
+    // the delete handler (db.rs resolve_alias). It therefore reaches the delete
+    // lookup and yields "No Such Key". Pre-TC-119 the alias fell through the
+    // dispatch match (`_ => {}`) and the invocation was a silent no-op success.
+    let (_status, body) = kv_invoke(
+        &client,
+        holder_invocation(
+            &holder_jwk,
+            &holder_did,
+            &holder_vm,
+            kv_del_grant,
+            &kv_resource,
+            "tinycloud.kv/delete",
+            "urn:uuid:00000000-0000-4000-8000-00000000c102",
+        )?,
+    )
+    .await;
+    assert!(
+        body.contains("No Such Key"),
+        "kv/delete request must dispatch as del (reach the delete lookup): {body}"
+    );
+
+    // --- KV NEGATIVE: `kv/delete` grant must NOT authorize `kv/get` ---
+    let (status, body) = kv_invoke(
+        &client,
+        holder_invocation(
+            &holder_jwk,
+            &holder_did,
+            &holder_vm,
+            kv_del_grant,
+            &kv_resource,
+            "tinycloud.kv/get",
+            "urn:uuid:00000000-0000-4000-8000-00000000c103",
+        )?,
+    )
+    .await;
+    assert_eq!(status, Status::Unauthorized);
+    assert!(
+        body.contains("Unauthorized Action"),
+        "kv/delete grant must NOT authorize kv/get (undeclared): {body}"
+    );
+
+    // --- SQL: implication (grant `sql/admin` ⊃ request `sql/schema`) ---
+    let resp = client
+        .post("/invoke")
+        .header(Header::new(
+            "Authorization",
+            holder_invocation(
+                &holder_jwk,
+                &holder_did,
+                &holder_vm,
+                sql_admin_grant,
+                &sql_resource,
+                "tinycloud.sql/schema",
+                "urn:uuid:00000000-0000-4000-8000-00000000c201",
+            )?,
+        ))
+        .header(ContentType::JSON)
+        .body(serde_json::to_string(&SqlRequest::Execute {
+            schema: None,
+            sql: "CREATE TABLE holder_created (x INTEGER)".to_string(),
+            params: vec![],
+        })?)
+        .dispatch()
+        .await;
+    let status = resp.status();
+    let body = resp.into_string().await.unwrap_or_default();
+    assert_eq!(
+        status,
+        Status::Ok,
+        "sql/admin grant must authorize an sql/schema DDL invocation live: {body}"
+    );
+
+    // --- SQL NEGATIVE: `sql/admin` grant must NOT authorize `sql/write` ---
+    // The registry declares `admin ⊃ schema` only, NOT `admin ⊃ write`.
+    let resp = client
+        .post("/invoke")
+        .header(Header::new(
+            "Authorization",
+            holder_invocation(
+                &holder_jwk,
+                &holder_did,
+                &holder_vm,
+                sql_admin_grant,
+                &sql_resource,
+                "tinycloud.sql/write",
+                "urn:uuid:00000000-0000-4000-8000-00000000c202",
+            )?,
+        ))
+        .header(ContentType::JSON)
+        .body(serde_json::to_string(&SqlRequest::Execute {
+            schema: None,
+            sql: "INSERT INTO seed (id) VALUES (2)".to_string(),
+            params: vec![],
+        })?)
+        .dispatch()
+        .await;
+    let status = resp.status();
+    let body = resp.into_string().await.unwrap_or_default();
+    assert_eq!(
+        status,
+        Status::Unauthorized,
+        "sql/admin grant must NOT authorize sql/write (undeclared): {body}"
+    );
+
+    Ok(())
+}

--- a/tinycloud-core/src/db.rs
+++ b/tinycloud-core/src/db.rs
@@ -558,7 +558,11 @@ where
                 Some((
                     r.space(),
                     r.service().as_str(),
-                    cap.ability.as_ref().as_ref(),
+                    // TC-119: resolve deprecated aliases to canonical so an
+                    // invocation using `kv/delete` dispatches identically to
+                    // `kv/del`. Identity for canonical URNs, so dispatch for
+                    // every non-alias action is byte-for-byte unchanged.
+                    crate::policy_capability::resolve_alias(cap.ability.as_ref().as_ref()),
                     r.path()?,
                 ))
             }) {
@@ -629,7 +633,9 @@ where
                 Some((
                     r.space(),
                     r.service().as_str(),
-                    c.ability.as_ref().as_ref(),
+                    // TC-119: resolve deprecated aliases to canonical (see the
+                    // staging loop above) — identity for canonical URNs.
+                    crate::policy_capability::resolve_alias(c.ability.as_ref().as_ref()),
                     r.path()?,
                 ))
             })

--- a/tinycloud-core/src/duckdb/parser.rs
+++ b/tinycloud-core/src/duckdb/parser.rs
@@ -4,6 +4,7 @@ use sqlparser::parser::Parser;
 
 use super::caveats::DuckDbCaveats;
 use super::types::DuckDbError;
+use crate::policy_capability::{ability_matches, resolve_alias};
 use crate::write_hooks::TouchedTables;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -26,11 +27,12 @@ pub fn validate_sql(
     caveats: &Option<DuckDbCaveats>,
     ability: &str,
 ) -> Result<ParsedQuery, DuckDbError> {
-    let is_admin = matches!(ability, "tinycloud.duckdb/admin" | "tinycloud.duckdb/*");
-    let has_write = matches!(
-        ability,
-        "tinycloud.duckdb/write" | "tinycloud.duckdb/admin" | "tinycloud.duckdb/*"
-    );
+    // TC-119: registry-aware capability tiers. `duckdb/*` implies every duckdb
+    // action, so it confers admin and write. `duckdb/admin` does NOT imply
+    // write in the registry, so `has_write` keeps admin via the `is_admin`
+    // term — reproducing the prior `admin | write | *` set exactly.
+    let is_admin = ability_matches(ability, "tinycloud.duckdb/admin");
+    let has_write = is_admin || ability_matches(ability, "tinycloud.duckdb/write");
 
     // Tier 3: Check if SQL is in pre-approved statements list
     if let Some(ref c) = caveats {
@@ -125,7 +127,10 @@ pub fn validate_sql(
         ));
     }
 
-    if !is_read_only && matches!(ability, "tinycloud.duckdb/read" | "tinycloud.duckdb/select") {
+    // Exact-tier restriction: read-tier (`read`, or its `select` alias) cannot
+    // run a write. Exact by design — `duckdb/*` implies read but must still
+    // permit writes, so this must not use `ability_matches`.
+    if !is_read_only && resolve_alias(ability) == "tinycloud.duckdb/read" {
         return Err(DuckDbError::ReadOnlyViolation);
     }
 

--- a/tinycloud-core/src/models/delegation.rs
+++ b/tinycloud-core/src/models/delegation.rs
@@ -280,10 +280,22 @@ async fn validate<C: ConnectionTrait>(
             // we require structural equality so a child cannot silently
             // replace a parent's caveat.
             for c in &dependant_caps {
+                // TC-119: registry-aware ability containment (same primitive as
+                // the invocation boundary). A parent ability supports the child
+                // when equal OR a registry alias OR an implication of it. Strict
+                // widening of the previous `c.ability == pc.ability` — exact
+                // matches still match; only registry-declared alias/implication
+                // pairs are added.
                 let mut candidates = parent_abilities
                     .iter()
                     .flatten()
-                    .filter(|pc| c.resource.extends(&pc.resource) && c.ability == pc.ability)
+                    .filter(|pc| {
+                        c.resource.extends(&pc.resource)
+                            && crate::policy_capability::ability_matches(
+                                pc.ability.as_ref().as_ref(),
+                                c.ability.as_ref().as_ref(),
+                            )
+                    })
                     .peekable();
 
                 if candidates.peek().is_none() {

--- a/tinycloud-core/src/models/invocation.rs
+++ b/tinycloud-core/src/models/invocation.rs
@@ -216,10 +216,23 @@ async fn validate<C: ConnectionTrait>(
             // the persisted chain ability row already has a matching or
             // stricter caveat.
             for c in &dependant_caps {
+                // TC-119: ability containment is registry-aware. A parent
+                // ability supports the invoked ability when it is equal OR a
+                // registry-declared alias (`kv/delete`↔`kv/del`) OR implies it
+                // (`sql/admin` ⊃ `sql/schema`; `sql/*` ⊃ every sql action).
+                // This is a strict widening of the previous `c.ability ==
+                // pc.ability`: exact matches still match, only registry
+                // alias/implication pairs are added.
                 let mut candidates = parents
                     .iter()
                     .flat_map(|(_, a)| a)
-                    .filter(|pc| c.resource.extends(&pc.resource) && c.ability == pc.ability)
+                    .filter(|pc| {
+                        c.resource.extends(&pc.resource)
+                            && crate::policy_capability::ability_matches(
+                                pc.ability.as_ref().as_ref(),
+                                c.ability.as_ref().as_ref(),
+                            )
+                    })
                     .peekable();
 
                 if candidates.peek().is_none() {

--- a/tinycloud-core/src/policy_capability/mod.rs
+++ b/tinycloud-core/src/policy_capability/mod.rs
@@ -34,6 +34,39 @@ pub fn accepted_actions(service: &str) -> Option<&'static [&'static str]> {
     generated::accepted_actions(service)
 }
 
+/// Resolve a deprecated-alias action URN to its canonical form (registry
+/// SSOT — e.g. `tinycloud.kv/delete` → `tinycloud.kv/del`). Identity for
+/// canonical or unknown URNs. Re-exported so the live wire paths (invocation
+/// dispatch, exact-tier authorization gates) resolve aliases the *same* way
+/// the containment engine does, instead of hand-maintaining alias lists.
+pub fn resolve_alias(action: &str) -> &str {
+    generated::resolve_alias(action)
+}
+
+/// Does holding `held` satisfy a requirement for `required`, accounting for
+/// deprecated-alias equivalence and implication expansion exactly as the
+/// registry declares — and nothing more (TC-119)?
+///
+/// This is the single capability-comparison primitive for the live wire
+/// paths: UCAN delegation/invocation chain containment and the per-service
+/// authorization gates (SQL/DuckDB parsers, the rusqlite authorizer, the
+/// route-level admin checks). It is a strict *widening* of byte equality:
+///
+///   * when `held == required` it always returns `true` (so every request
+///     authorized before this change is still authorized), and
+///   * it returns `true` for additional pairs ONLY where the registry
+///     declares an alias (`kv/delete`↔`kv/del`, `sql/select`↔`sql/read`,
+///     `duckdb/select`↔`duckdb/read`) or an implication (`sql/admin` ⊃
+///     `sql/schema`; `sql/*` / `duckdb/*` ⊃ every action for their service).
+///
+/// For URNs the registry does not know it degrades to exact string equality,
+/// so it never widens anything the registry has not declared. Stored URNs are
+/// never rewritten; only the comparison is registry-aware, so persisted
+/// capability rows, hashes, and serialized formats are unaffected.
+pub fn ability_matches(held: &str, required: &str) -> bool {
+    expand_actions(std::iter::once(held)).contains(generated::resolve_alias(required))
+}
+
 /// PolicyCapability — resolved authority shape used by ceilings, requested
 /// capabilities, delegation expansion, and grant issuance.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -346,13 +379,16 @@ impl PolicyCapability {
     }
 }
 
-/// Build the set of canonical action URNs a grant authorizes, resolving
-/// deprecated aliases to their canonical form and expanding implications
-/// (e.g. `sql/admin` pulls in `sql/schema`) transitively. Used only for the
-/// containment subset check; it never mutates stored actions or hashes.
-fn expand_granted_actions(actions: &[String]) -> std::collections::HashSet<&str> {
-    let mut out: std::collections::HashSet<&str> = std::collections::HashSet::new();
-    let mut stack: Vec<&str> = actions.iter().map(String::as_str).collect();
+/// Build the set of canonical action URNs a set of held actions authorizes,
+/// resolving deprecated aliases to their canonical form and expanding
+/// implications (e.g. `sql/admin` pulls in `sql/schema`) transitively. Used
+/// by both the containment subset check and `ability_matches`; it never
+/// mutates stored actions or hashes.
+fn expand_actions<'a>(
+    actions: impl IntoIterator<Item = &'a str>,
+) -> std::collections::HashSet<&'a str> {
+    let mut out: std::collections::HashSet<&'a str> = std::collections::HashSet::new();
+    let mut stack: Vec<&'a str> = actions.into_iter().collect();
     while let Some(action) = stack.pop() {
         let canonical = generated::resolve_alias(action);
         if out.insert(canonical) {
@@ -362,6 +398,10 @@ fn expand_granted_actions(actions: &[String]) -> std::collections::HashSet<&str>
         }
     }
     out
+}
+
+fn expand_granted_actions(actions: &[String]) -> std::collections::HashSet<&str> {
+    expand_actions(actions.iter().map(String::as_str))
 }
 
 /// Path containment per service. For KV/VFS, a trailing-slash auth.path is a
@@ -759,5 +799,140 @@ mod tests {
 
     fn resolve_alias_via_generated(a: &str) -> &str {
         generated::resolve_alias(a)
+    }
+
+    // --- TC-119: `ability_matches` (the live-wire comparison primitive) ---
+
+    #[test]
+    fn ability_matches_is_reflexive_over_every_registry_action() {
+        // Monotonicity floor: for EVERY URN the registry knows, holding it
+        // satisfies a request for the same URN. This is the property the wire
+        // paths rely on (every previously-authorized exact match still holds).
+        let registry: Registry = serde_json::from_str(REGISTRY_JSON).unwrap();
+        for e in &registry.capabilities {
+            assert!(
+                ability_matches(&e.urn, &e.urn),
+                "{} must match itself",
+                e.urn
+            );
+        }
+    }
+
+    #[test]
+    fn ability_matches_resolves_aliases_both_directions() {
+        // A grant in either the canonical or the deprecated-alias form must
+        // authorize a request in either form.
+        for (canonical, alias) in [
+            ("tinycloud.kv/del", "tinycloud.kv/delete"),
+            ("tinycloud.sql/read", "tinycloud.sql/select"),
+            ("tinycloud.duckdb/read", "tinycloud.duckdb/select"),
+        ] {
+            assert!(ability_matches(alias, canonical), "{alias} ⊇ {canonical}");
+            assert!(ability_matches(canonical, alias), "{canonical} ⊇ {alias}");
+            assert!(ability_matches(alias, alias));
+            assert!(ability_matches(canonical, canonical));
+        }
+    }
+
+    #[test]
+    fn ability_matches_expands_implications_one_directionally() {
+        // admin ⊃ schema (TC-109), but schema does NOT confer admin, and admin
+        // does NOT confer write (the registry only declares admin ⊃ schema).
+        assert!(ability_matches(
+            "tinycloud.sql/admin",
+            "tinycloud.sql/schema"
+        ));
+        assert!(!ability_matches(
+            "tinycloud.sql/schema",
+            "tinycloud.sql/admin"
+        ));
+        assert!(!ability_matches(
+            "tinycloud.sql/admin",
+            "tinycloud.sql/write"
+        ));
+        assert!(!ability_matches(
+            "tinycloud.sql/admin",
+            "tinycloud.sql/read"
+        ));
+        // DuckDB admin implies nothing (only the wildcard does).
+        assert!(!ability_matches(
+            "tinycloud.duckdb/admin",
+            "tinycloud.duckdb/write"
+        ));
+        assert!(!ability_matches(
+            "tinycloud.duckdb/admin",
+            "tinycloud.duckdb/read"
+        ));
+    }
+
+    #[test]
+    fn ability_matches_wildcard_covers_every_service_action() {
+        for req in [
+            "tinycloud.sql/read",
+            "tinycloud.sql/write",
+            "tinycloud.sql/schema",
+            "tinycloud.sql/admin",
+            "tinycloud.sql/select", // alias resolves under the wildcard too
+        ] {
+            assert!(
+                ability_matches("tinycloud.sql/*", req),
+                "sql/* must confer {req}"
+            );
+        }
+        for req in [
+            "tinycloud.duckdb/read",
+            "tinycloud.duckdb/write",
+            "tinycloud.duckdb/admin",
+            "tinycloud.duckdb/import",
+            "tinycloud.duckdb/export",
+        ] {
+            assert!(
+                ability_matches("tinycloud.duckdb/*", req),
+                "duckdb/* must confer {req}"
+            );
+        }
+        // Wildcards never cross service boundaries.
+        assert!(!ability_matches("tinycloud.sql/*", "tinycloud.duckdb/read"));
+        assert!(!ability_matches("tinycloud.duckdb/*", "tinycloud.sql/read"));
+    }
+
+    #[test]
+    fn ability_matches_rejects_unrelated_and_lower_tiers() {
+        // read does not confer write; a wildcard req is never satisfied by a
+        // concrete grant; distinct kv actions do not cross-authorize.
+        assert!(!ability_matches(
+            "tinycloud.sql/read",
+            "tinycloud.sql/write"
+        ));
+        assert!(!ability_matches("tinycloud.sql/write", "tinycloud.sql/*"));
+        assert!(!ability_matches("tinycloud.kv/get", "tinycloud.kv/put"));
+        assert!(!ability_matches("tinycloud.kv/get", "tinycloud.kv/del"));
+    }
+
+    #[test]
+    fn ability_matches_degrades_to_exact_equality_off_registry() {
+        // For URNs the registry does not model, `ability_matches` is exactly
+        // string equality — it never widens anything undeclared.
+        assert!(ability_matches(
+            "tinycloud.encryption/decrypt",
+            "tinycloud.encryption/decrypt"
+        ));
+        assert!(!ability_matches(
+            "tinycloud.encryption/decrypt",
+            "tinycloud.encryption/network.create"
+        ));
+        assert!(ability_matches(
+            "totally.unknown/thing",
+            "totally.unknown/thing"
+        ));
+        assert!(!ability_matches("totally.unknown/a", "totally.unknown/b"));
+    }
+
+    #[test]
+    fn resolve_alias_reexport_matches_generated() {
+        assert_eq!(resolve_alias("tinycloud.kv/delete"), "tinycloud.kv/del");
+        assert_eq!(resolve_alias("tinycloud.kv/del"), "tinycloud.kv/del");
+        assert_eq!(resolve_alias("tinycloud.sql/select"), "tinycloud.sql/read");
+        assert_eq!(resolve_alias("unknown/x"), "unknown/x");
     }
 }

--- a/tinycloud-core/src/sql/authorizer.rs
+++ b/tinycloud-core/src/sql/authorizer.rs
@@ -1,13 +1,15 @@
 use rusqlite::hooks::{AuthAction, AuthContext, Authorization};
 
 use super::caveats::SqlCaveats;
+use crate::policy_capability::{ability_matches, resolve_alias};
 
 fn can_write_data(ability: &str, is_admin: bool) -> bool {
-    is_admin
-        || matches!(
-            ability,
-            "tinycloud.sql/admin" | "tinycloud.sql/write" | "tinycloud.sql/*"
-        )
+    // TC-119: confers-write gate (registry-aware). `admin` is covered by the
+    // `is_admin` flag; `write` matches directly; `sql/*` matches via the
+    // registry implication `* ⊃ write`. Identical to the prior
+    // `admin | write | *` set. NOTE: `schema` does NOT confer write here (the
+    // registry declares `admin ⊃ schema`, not `schema ⊃ write`).
+    is_admin || ability_matches(ability, "tinycloud.sql/write")
 }
 
 fn is_sqlite_schema_table(table_name: &str) -> bool {
@@ -18,8 +20,11 @@ fn is_sqlite_schema_table(table_name: &str) -> bool {
 }
 
 fn can_write_table(ability: &str, is_admin: bool, table_name: &str) -> bool {
+    // The second clause is an exact-tier match on `schema` (writes to the
+    // sqlite schema tables during DDL), NOT a confers-check — so compare the
+    // alias-resolved URN rather than using `ability_matches`.
     can_write_data(ability, is_admin)
-        || (ability == "tinycloud.sql/schema" && is_sqlite_schema_table(table_name))
+        || (resolve_alias(ability) == "tinycloud.sql/schema" && is_sqlite_schema_table(table_name))
 }
 
 pub fn create_authorizer(
@@ -166,7 +171,7 @@ pub fn create_authorizer(
             column_name,
         } => {
             if !is_admin
-                && matches!(ability.as_str(), "tinycloud.sql/schema")
+                && resolve_alias(ability.as_str()) == "tinycloud.sql/schema"
                 && !schema_ddl_authorized
                 && !is_sqlite_schema_table(table_name)
             {
@@ -241,17 +246,16 @@ pub fn create_authorizer(
         // SQLite fires SQLITE_REINDEX while building an index; gate it like the
         // CreateIndex it accompanies so an authorized CREATE INDEX can complete.
         | AuthAction::Reindex { .. } => {
-            if !is_admin
-                && !matches!(
-                    ability.as_str(),
-                    "tinycloud.sql/write"
-                        | "tinycloud.sql/schema"
-                        | "tinycloud.sql/*"
-                )
+            // TC-119: DDL is permitted for abilities that confer write OR
+            // schema (`sql/*` implies both). Equivalent to the prior
+            // `write | schema | *` set; `admin` is handled by `is_admin`.
+            if !(is_admin
+                || ability_matches(ability.as_str(), "tinycloud.sql/write")
+                || ability_matches(ability.as_str(), "tinycloud.sql/schema"))
             {
                 Authorization::Deny
             } else {
-                if !is_admin && matches!(ability.as_str(), "tinycloud.sql/schema") {
+                if !is_admin && resolve_alias(ability.as_str()) == "tinycloud.sql/schema" {
                     schema_ddl_authorized = true;
                 }
                 Authorization::Allow
@@ -261,7 +265,7 @@ pub fn create_authorizer(
         // Allow internal operations
         AuthAction::Transaction { .. } | AuthAction::Savepoint { .. } | AuthAction::Select => {
             if !is_admin
-                && matches!(ability.as_str(), "tinycloud.sql/schema")
+                && resolve_alias(ability.as_str()) == "tinycloud.sql/schema"
                 && !schema_ddl_authorized
             {
                 return Authorization::Deny;

--- a/tinycloud-core/src/sql/database.rs
+++ b/tinycloud-core/src/sql/database.rs
@@ -174,7 +174,9 @@ fn handle_message(
     caveats: &Option<SqlCaveats>,
     ability: &str,
 ) -> Result<SqlExecutionResult, SqlError> {
-    let is_admin = matches!(ability, "tinycloud.sql/admin" | "tinycloud.sql/*");
+    // TC-119: confers-admin gate (registry-aware). `sql/admin` and `sql/*`
+    // (implies admin) pass; identical to the prior `admin | *` match.
+    let is_admin = crate::policy_capability::ability_matches(ability, "tinycloud.sql/admin");
 
     match request {
         SqlRequest::Query { sql, params } => {

--- a/tinycloud-core/src/sql/parser.rs
+++ b/tinycloud-core/src/sql/parser.rs
@@ -4,6 +4,7 @@ use sqlparser::parser::Parser;
 
 use super::caveats::SqlCaveats;
 use super::types::SqlError;
+use crate::policy_capability::{ability_matches, resolve_alias};
 use crate::write_hooks::TouchedTables;
 
 #[derive(Debug)]
@@ -22,7 +23,9 @@ pub fn validate_sql(
     ability: &str,
 ) -> Result<ParsedQuery, SqlError> {
     if is_pragma_sql(sql) {
-        if !matches!(ability, "tinycloud.sql/admin" | "tinycloud.sql/*") {
+        // TC-119: confers-admin gate. `sql/admin` and `sql/*` (implies admin)
+        // pass; identical to the prior `admin | *` match.
+        if !ability_matches(ability, "tinycloud.sql/admin") {
             return Err(SqlError::PermissionDenied(
                 "PRAGMA operations require admin ability".to_string(),
             ));
@@ -112,27 +115,32 @@ pub fn validate_sql(
     }
 
     // Validate ability vs operation type
+    // TC-119: DDL requires an ability that confers write OR schema. `sql/admin`
+    // qualifies because the registry declares `admin ⊃ schema`; `sql/*` qualifies
+    // because it implies both. This reproduces the prior `admin|write|schema|*`
+    // set exactly, now sourced from the registry implication table.
     if is_ddl
-        && !matches!(
-            ability,
-            "tinycloud.sql/admin"
-                | "tinycloud.sql/write"
-                | "tinycloud.sql/schema"
-                | "tinycloud.sql/*"
-        )
+        && !(ability_matches(ability, "tinycloud.sql/write")
+            || ability_matches(ability, "tinycloud.sql/schema"))
     {
         return Err(SqlError::PermissionDenied(
             "DDL operations require admin, schema, or write ability".to_string(),
         ));
     }
 
-    if matches!(ability, "tinycloud.sql/schema") && (!is_ddl || has_non_ddl) {
+    // Exact-tier restriction: the `schema` ability is DDL-only. This is NOT a
+    // confers-check — it must stay exact (a broader ability like `admin` is not
+    // restricted here), so we compare the alias-resolved URN, not `ability_matches`.
+    if resolve_alias(ability) == "tinycloud.sql/schema" && (!is_ddl || has_non_ddl) {
         return Err(SqlError::PermissionDenied(
             "Schema ability only permits DDL operations".to_string(),
         ));
     }
 
-    if !is_read_only && matches!(ability, "tinycloud.sql/read" | "tinycloud.sql/select") {
+    // Exact-tier restriction: read-tier (`read`, or its `select` alias) cannot
+    // run a write. Exact by design — `sql/*` implies read but must still permit
+    // writes, so this must not use `ability_matches`.
+    if !is_read_only && resolve_alias(ability) == "tinycloud.sql/read" {
         return Err(SqlError::ReadOnlyViolation);
     }
 

--- a/tinycloud-node-server/src/routes/mod.rs
+++ b/tinycloud-node-server/src/routes/mod.rs
@@ -2124,9 +2124,17 @@ fn preferred_database_ability<'a>(
         _ => &[],
     };
 
+    // TC-119: match held abilities to the (privilege-ordered) preferred slots
+    // by their canonical form, so a held deprecated alias (e.g. `sql/select`)
+    // matches its canonical slot. Identity for canonical URNs — the privilege
+    // ordering and the returned (unmodified) held ability are unchanged.
     preferred_abilities.iter().find_map(|preferred| {
+        let preferred_canonical = tinycloud_core::policy_capability::resolve_alias(preferred);
         caps.iter()
-            .find(|(_, _, ability)| ability.as_str() == *preferred)
+            .find(|(_, _, ability)| {
+                tinycloud_core::policy_capability::resolve_alias(ability.as_str())
+                    == preferred_canonical
+            })
             .map(|(_, _, ability)| ability.as_str())
     })
 }
@@ -2135,14 +2143,18 @@ fn has_database_admin_capability(
     caps: &[(tinycloud_auth::resource::SpaceId, Option<String>, String)],
     service: &str,
 ) -> bool {
-    let admin_abilities: &[&str] = match service {
-        "sql" => &["tinycloud.sql/admin", "tinycloud.sql/*"],
-        "duckdb" => &["tinycloud.duckdb/admin", "tinycloud.duckdb/*"],
-        _ => &[],
+    // TC-119: confers-admin gate (registry-aware). Both `<svc>/admin` and the
+    // per-service wildcard (which implies admin) confer admin — identical to
+    // the prior explicit `{admin, *}` list, now via the registry.
+    let admin_ability = match service {
+        "sql" => "tinycloud.sql/admin",
+        "duckdb" => "tinycloud.duckdb/admin",
+        _ => return false,
     };
 
-    caps.iter()
-        .any(|(_, _, ability)| admin_abilities.contains(&ability.as_str()))
+    caps.iter().any(|(_, _, ability)| {
+        tinycloud_core::policy_capability::ability_matches(ability.as_str(), admin_ability)
+    })
 }
 
 fn missing_database_admin_capability_error(

--- a/tinycloud-node-server/src/routes/mod.rs
+++ b/tinycloud-node-server/src/routes/mod.rs
@@ -1056,7 +1056,12 @@ async fn emit_kv_hook_events(
                 Some((
                     resource.space(),
                     resource.service().as_str(),
-                    capability.ability.as_ref().as_ref(),
+                    // Resolve deprecated aliases (e.g. kv/delete -> kv/del) so
+                    // alias-invoked operations emit the same live-bus events as
+                    // canonical ones — mirrors the db.rs dispatch resolution.
+                    tinycloud_core::policy_capability::resolve_alias(
+                        capability.ability.as_ref().as_ref(),
+                    ),
                     resource.path()?,
                 ))
             })


### PR DESCRIPTION
## TC-119: wire the TC-112 capability registry into the live `/invoke` + `/delegate` paths

TC-112 (#98, merged @ e9be896) built the capability registry (`capabilities.json` → `policy_capability/generated.rs`: `accepted_actions` / `resolve_alias` / `implied_actions`) but consumed it **only** in the policy-capability contract layer + the SQL constrained-statement caveat. The live wire paths still hard-coded ability strings, so the registry's alias resolution (`kv/delete`↔`kv/del`, `sql/select`↔`sql/read`, `duckdb/select`↔`duckdb/read`), implication expansion (`sql/admin ⊃ sql/schema` — TC-109), and wildcard semantics never reached real delegations/invocations. This PR completes the single-source-of-truth enforcement.

### Design — one primitive, used everywhere

New in `tinycloud-core/src/policy_capability/mod.rs`:

- **`ability_matches(held, required) -> bool`** — the single capability-comparison primitive. Resolves aliases on both sides and expands implications (transitively) on the `held` side, then checks membership. It is a **strict widening of byte equality**: `held == required` always returns `true`, and it returns `true` for *additional* pairs **only** where the registry declares an alias or implication. For URNs the registry does not model it degrades to exact string equality. (Refactored the existing `expand_granted_actions` to share one `expand_actions` closure so `contains()` and `ability_matches` can't diverge.)
- **`resolve_alias(action)`** — re-export of the generated single-hop alias resolver, for dispatch + exact-tier gates.

Two comparison shapes are used at call sites, and the distinction is load-bearing:
- **"confers tier X"** (superset) checks → `ability_matches(held, X)`.
- **"is exactly tier X"** (restriction) checks → `resolve_alias(x) == X` (never `ability_matches`, which would wrongly let a broader ability trip a narrower restriction).

### Call sites changed (before → after)

| # | File:sym | Kind | Before | After | Net behavior |
|---|----------|------|--------|-------|--------------|
| 1 | `models/invocation.rs` `validate` | **chain auth** (`/invoke`) | `c.ability == pc.ability` | `ability_matches(pc, c)` | alias + implication now authorize invocations; exact matches unchanged |
| 2 | `models/delegation.rs` `validate` | **chain auth** (`/delegate`) | `c.ability == pc.ability` | `ability_matches(pc, c)` | same, for redelegation |
| 3 | `db.rs` invoke (staging + side-effect loops) | **dispatch** | match on `cap.ability` | match on `resolve_alias(cap.ability)` | `kv/delete` invocation dispatches as `kv/del`; **byte-identical for every canonical URN** |
| 4 | `sql/parser.rs` pragma gate | confers-admin | `matches!(admin\|*)` | `ability_matches(a,"sql/admin")` | identical set `{admin,*}` |
| 5 | `sql/parser.rs` DDL gate | confers write∪schema | `matches!(admin\|write\|schema\|*)` | `ability_matches(a,write) \|\| ability_matches(a,schema)` | identical set (admin covered via `admin⊃schema`, `*` via impl) |
| 6 | `sql/parser.rs` schema-only restriction | exact-tier | `matches!(schema)` | `resolve_alias(a)=="sql/schema"` | identical (schema has no alias) |
| 7 | `sql/parser.rs` read-only restriction | exact-tier | `matches!(read\|select)` | `resolve_alias(a)=="sql/read"` | identical; `*` still permits writes |
| 8 | `sql/database.rs` `handle_message` | confers-admin | `matches!(admin\|*)` | `ability_matches(a,"sql/admin")` | identical |
| 9 | `sql/authorizer.rs` `can_write_data` | confers-write | `is_admin \|\| matches!(admin\|write\|*)` | `is_admin \|\| ability_matches(a,write)` | identical (schema still excluded) |
| 10 | `sql/authorizer.rs` `can_write_table` | exact-tier | `a=="schema"` | `resolve_alias(a)=="schema"` | identical |
| 11 | `sql/authorizer.rs` Read gate / DDL gate / Select gate | exact-tier + confers | `matches!(...)` | `resolve_alias`/`ability_matches` per kind | identical |
| 12 | `duckdb/parser.rs` `is_admin` / `has_write` | confers | `matches!(...)` | `ability_matches` (admin kept in `has_write` via `is_admin` since **duckdb/admin does not imply write** in the registry) | identical set |
| 13 | `duckdb/parser.rs` read-only restriction | exact-tier | `matches!(read\|select)` | `resolve_alias(a)=="duckdb/read"` | identical |
| 14 | `routes/mod.rs` `has_database_admin_capability` | confers-admin | `{admin,*}.contains` | `ability_matches(a, admin)` | identical |
| 15 | `routes/mod.rs` `preferred_database_ability` | selection | `a == preferred` | `resolve_alias(a)==resolve_alias(preferred)` | identical returned ability; privilege order unchanged |

### Monotonicity argument (strict, registry-bounded widening)

`ability_matches(h,r)` ⊇ `(h == r)` for **all** inputs: when `h==r`, `resolve_alias(h)==resolve_alias(r)` is the seed of `h`'s expansion, so membership holds. The **only** extra `true` results come from registry-declared aliases/implications. For URNs the registry doesn't model (encryption, space/host, vfs, unknown), `resolve_alias` is identity and `implied_actions` is empty, so `ability_matches` **is** string equality — nothing undeclared widens. Therefore every request authorized before is still authorized (sites 1–2), and every hardcoded set was reproduced exactly (sites 4–15, proven per-row and guarded by the pre-existing SQL/DuckDB/authorizer test suites which pass unchanged). Dispatch (site 3) is `resolve_alias`-only: identity for canonical URNs ⇒ **byte-identical dispatch**; the sole non-identity input relevant to KV dispatch is `kv/delete`, which now maps to the `del` arm instead of falling through.

Exact-tier restrictions deliberately **do not** use `ability_matches` (sites 6, 7, 10, 11, 13): e.g. `sql/*` implies `read`, but the read-only-violation gate must still let `*` write — so it stays `resolve_alias(a)=="sql/read"`. Using `ability_matches` there would be a non-monotonic *narrowing* of broader abilities; avoiding it is why the split exists.

No stored data, capability hashes, or serialized formats change — only comparisons are registry-aware.

### Chain-containment grounding finding

**The chain-containment comparison is in-repo and in-scope.** Both `/invoke` (`models/invocation.rs:222`) and `/delegate` (`models/delegation.rs:286`) filter candidate parent abilities with `c.resource.extends(&pc.resource) && c.ability == pc.ability` — plain `==`, no aliasing. The `Ability` type's `==` comes from the external git crate `ucan-capabilities-object` (byte-for-byte `PartialEq` on a `nutype` String), but the **containment logic** is this repo's own code, so wrapping the ability half in `ability_matches` makes aliasing/implication go live at the chain level. The vendored `dependencies/{siwe,siwe-recap,cacao}` tree parses CACAO/siwe-recap envelopes and does **not** perform this comparison. Confirmed empirically: before this change a `kv/delete` grant + `kv/del` invocation is rejected with `UnauthorizedAction`; after, it is authorized (see live test below).

### Test matrix

- **Unit** — 7 new `ability_matches`/`resolve_alias` tests (alias both directions; `admin⊃schema` one-directional + `admin⊉write`, `duckdb/admin⊉write`; per-service wildcard incl. cross-service isolation; lower-tier + unrelated negatives; off-registry exact-equality; reflexivity over **every** registry URN). All existing W0/W1 policy-capability + SQL/DuckDB/authorizer vectors pass **unchanged** (regression guard for sites 4–15).
- `cargo test --workspace` (default features): all TinyCloud crates green. (Pre-existing `dependencies/siwe::tests::verification1` failure is unrelated — expired-SIWE EIP-191, identical on clean main, not run by CI's `cargo test`; it fail-fast aborts `--workspace`, so ran `--exclude siwe` for the full green signal.)
- `cargo test -p tinycloud-core --features duckdb`: 148 passed (covers the duckdb parser changes).
- `cargo fmt --all --check`: clean. `cargo clippy --workspace --all-targets --features duckdb -- -Dwarnings`: clean.
- **w5 E2E** (`test/w5-policy-runtime-node-e2e`): positive path green **through** the changed containment code on this branch; the revocation leg hits the pre-existing TC-120 nonce-reuse bug (409 vs 401) identical to clean main. Re-ran on a throwaway merge with `fix/tc-120-w5-fresh-nonce` (origin @ e2a4d3e) → **full E2E incl. revocation green** (kept out of this PR's diff).
- **NEW live proof** — `test/w5-policy-runtime-node-e2e/tests/tc119_registry_wire_paths.rs`: boots the real node and dispatches holder-signed UCAN invocations citing a root-authority delegation row:
  - `kv/delete` grant → `kv/del` invocation clears the chain check (reaches empty-store "No Such Key", not "Unauthorized Action") — chain alias ✅
  - `kv/delete` *invocation* dispatches as `del` (db.rs) — reaches "No Such Key" (pre-TC-119 it was a silent no-op success) ✅
  - `kv/delete` grant ⊭ `kv/get` → "Unauthorized Action" ✅ (no over-widening)
  - `sql/admin` grant → `sql/schema` DDL invocation → 200 ✅ (admin⊃schema live)
  - `sql/admin` grant ⊭ `sql/write` → 401 ✅ (admin⊃schema only)

### Deliberately not wired (and why)

- **`routes/hooks.rs` `validate_subscription` allowed-abilities + `is_hook_action_authorized`** — the `hooks` service has no registry aliases/implications, so `ability_matches` ≡ exact match there (no behavior change, nothing to de-duplicate). More importantly, accepting an alias in a subscription filter **without** normalizing the stored subscription ability (a stored-format change, out of scope per the "don't change serialized formats" constraint) would produce a subscription that validates but silently never matches events (events always carry canonical URNs from operation types). Widening here is not cleanly monotonic, so it is intentionally left exact.
- **`database_write_ability` / `missing_database_admin_capability_error`** — produce canonical *required* URNs; not checks.
- **`encryption_network`, `space/host`, `vfs`** — no registry aliases/implications; exact behavior preserved by `ability_matches`'s off-registry degradation.

Refs TC-119, TC-112, TC-109.
