### PR TITLE
fix: kv.delete on overwritten keys — S3 remove() head_object probe + storage error mapping (TC-140)

### DIFF
--- a/tinycloud-node-server/src/routes/mod.rs
+++ b/tinycloud-node-server/src/routes/mod.rs
@@ -35,6 +35,7 @@ use tinycloud_core::duckdb::{
 use tinycloud_core::{
     encryption_network::EncryptionService,
     events::Invocation,
+    keys::StaticSecret,
     models::{hook_delivery, hook_subscription, kv_delete, kv_write},
     sea_orm::DbErr,
     sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder},
@@ -959,17 +960,7 @@ async fn invoke_impl(
                     })
                 }
             }
-            Err(e) => Err((
-                match e {
-                    TxStoreError::Tx(TxError::SpaceNotFound) => Status::NotFound,
-                    TxStoreError::Tx(TxError::EpochInsert(_)) => Status::InternalServerError,
-                    TxStoreError::Tx(TxError::Db(DbErr::ConnectionAcquire(_))) => {
-                        Status::InternalServerError
-                    }
-                    _ => Status::Unauthorized,
-                },
-                e.to_string(),
-            )),
+            Err(e) => Err((map_invoke_error(&e), e.to_string())),
         };
 
         if let Some(timer) = timer {
@@ -2188,6 +2179,19 @@ fn missing_database_admin_capability_error(
     )
 }
 
+fn map_invoke_error(e: &TxStoreError<BlockStores, BlockStage, StaticSecret>) -> Status {
+    match e {
+        TxStoreError::Tx(TxError::SpaceNotFound) => Status::NotFound,
+        TxStoreError::Tx(TxError::EpochInsert(_)) => Status::InternalServerError,
+        TxStoreError::Tx(TxError::Db(DbErr::ConnectionAcquire(_))) => Status::InternalServerError,
+        TxStoreError::StoreRead(_)
+        | TxStoreError::StoreWrite(_)
+        | TxStoreError::StoreDelete(_)
+        | TxStoreError::Io(_) => Status::InternalServerError,
+        _ => Status::Unauthorized,
+    }
+}
+
 /// Verify authorization by invoking with empty inputs.
 ///
 /// Shared by SQL and DuckDB invoke handlers. The caller must extract caveats
@@ -2204,19 +2208,7 @@ async fn verify_auth(
     let result = tinycloud
         .invoke::<BlockStage>(invocation, HashMap::new())
         .await
-        .map_err(|e| {
-            (
-                match e {
-                    TxStoreError::Tx(TxError::SpaceNotFound) => Status::NotFound,
-                    TxStoreError::Tx(TxError::EpochInsert(_)) => Status::InternalServerError,
-                    TxStoreError::Tx(TxError::Db(DbErr::ConnectionAcquire(_))) => {
-                        Status::InternalServerError
-                    }
-                    _ => Status::Unauthorized,
-                },
-                e.to_string(),
-            )
-        })
+        .map_err(|e| (map_invoke_error(&e), e.to_string()))
         .map(|(tx_result, _)| tx_result);
     crate::prometheus::observe_span(
         span,
@@ -2232,7 +2224,10 @@ mod tests {
     use crate::{
         config::{Config, HooksConfig},
         quota::QuotaCache,
-        storage::file_system::FileSystemConfig as NodeFileSystemConfig,
+        storage::{
+            file_system::{FileSystemConfig as NodeFileSystemConfig, FileSystemStoreError},
+            s3::S3StoreError,
+        },
     };
     use anyhow::Result;
     use tempfile::TempDir;
@@ -2244,18 +2239,56 @@ mod tests {
     };
     use tinycloud_core::{
         keys::StaticSecret,
-        models::{hook_delivery, hook_subscription},
+        models::{hook_delivery, hook_subscription, invocation::InvocationError},
         sea_orm::{ColumnTrait, ConnectOptions, Database, EntityTrait, QueryFilter, QueryOrder},
-        storage::either::Either,
+        storage::either::{Either, EitherError},
         storage::StorageConfig as _,
         types::{Ability, Resource},
     };
     use tokio::time::{timeout, Duration};
 
+    type InvokeError = TxStoreError<BlockStores, BlockStage, StaticSecret>;
+    type BlockStoreError = EitherError<S3StoreError, FileSystemStoreError>;
+
     fn test_space_id(name: &str) -> SpaceId {
         let jwk = JWK::generate_ed25519().unwrap();
         let did: DIDBuf = DID_METHODS.generate(&jwk, "key").unwrap();
         SpaceId::new(did, name.parse().unwrap())
+    }
+
+    fn s3_store_error() -> BlockStoreError {
+        EitherError::A(S3StoreError::Io(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "s3 exploded",
+        )))
+    }
+
+    #[tokio::test]
+    async fn storage_errors_map_to_500_not_401() {
+        let errors = [
+            InvokeError::StoreDelete(s3_store_error()),
+            InvokeError::StoreRead(s3_store_error()),
+            InvokeError::StoreWrite(s3_store_error()),
+            InvokeError::Io(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "s3 exploded",
+            )),
+        ];
+
+        for error in errors {
+            assert_eq!(map_invoke_error(&error), Status::InternalServerError);
+        }
+    }
+
+    #[tokio::test]
+    async fn auth_and_notfound_mappings_unchanged() {
+        let not_found = InvokeError::Tx(TxError::SpaceNotFound);
+        assert_eq!(map_invoke_error(&not_found), Status::NotFound);
+
+        let auth_error = InvokeError::Tx(TxError::InvalidInvocation(
+            InvocationError::MissingKvWrite("missing".parse().unwrap()),
+        ));
+        assert_eq!(map_invoke_error(&auth_error), Status::Unauthorized);
     }
 
     async fn test_tinycloud() -> Result<TinyCloud> {

--- a/tinycloud-node-server/src/storage/s3.rs
+++ b/tinycloud-node-server/src/storage/s3.rs
@@ -1,8 +1,5 @@
 use aws_sdk_s3::{
-    error::{
-        GetObjectAttributesError, GetObjectAttributesErrorKind, GetObjectError, GetObjectErrorKind,
-        HeadObjectError, HeadObjectErrorKind,
-    },
+    error::{GetObjectError, GetObjectErrorKind, HeadObjectError, HeadObjectErrorKind},
     types::{ByteStream, SdkError},
     Client, // Config,
     Error as S3Error,
@@ -303,18 +300,17 @@ impl ImmutableDeleteStore for S3BlockStore {
     async fn remove(&self, space: &SpaceId, id: &Hash) -> Result<Option<()>, Self::Error> {
         let size: u64 = match self
             .client
-            .get_object_attributes()
+            .head_object()
             .bucket(&self.bucket)
             .key(self.key(space, id))
             .send()
             .await
         {
-            Ok(o) if !o.delete_marker() => o.object_size().try_into()?,
-            Ok(_) => return Ok(None),
+            Ok(o) => o.content_length().try_into()?,
             Err(SdkError::ServiceError {
                 err:
-                    GetObjectAttributesError {
-                        kind: GetObjectAttributesErrorKind::NoSuchKey(_),
+                    HeadObjectError {
+                        kind: HeadObjectErrorKind::NotFound(_),
                         ..
                     },
                 ..
@@ -344,5 +340,53 @@ impl StoreSize for S3BlockStore {
     type Error = S3StoreError;
     async fn total_size(&self, space: &SpaceId) -> Result<Option<u64>, Self::Error> {
         Ok(self.sizes.get_size(space).await)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use tinycloud_core::storage::{memory::MemoryStaging, ImmutableStaging, StorageConfig};
+
+    /// Live test against an S3-compatible endpoint (localstack). Run:
+    ///   docker run --rm -d -p 4566:4566 -e SERVICES=s3 localstack/localstack
+    ///   AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_REGION=us-east-1 \
+    ///   TINYCLOUD_TEST_S3_ENDPOINT=http://localhost:4566 \
+    ///   TINYCLOUD_TEST_S3_BUCKET=tinycloud-blocks-test \
+    ///   cargo test -p tinycloud-node s3_remove_lifecycle -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore = "requires live S3-compatible endpoint (localstack); see doc comment"]
+    async fn s3_remove_lifecycle() {
+        let endpoint =
+            std::env::var("TINYCLOUD_TEST_S3_ENDPOINT").expect("set TINYCLOUD_TEST_S3_ENDPOINT");
+        let bucket =
+            std::env::var("TINYCLOUD_TEST_S3_BUCKET").expect("set TINYCLOUD_TEST_S3_BUCKET");
+        let config = S3BlockConfig {
+            bucket: bucket.clone(),
+            endpoint: Some(endpoint.parse().unwrap()),
+        };
+
+        // Create the bucket idempotently BEFORE opening the store (S3BlockStore::new_ lists the bucket at s3.rs ~76, so it must exist).
+        let client = new_client(&config).await;
+        let _ = client.create_bucket().bucket(&bucket).send().await; // ignore "already exists"
+
+        let store = config.open().await.unwrap();
+        let space_id: SpaceId = "tinycloud:key:test:default".parse().unwrap();
+        store.create(&space_id).await.unwrap();
+
+        let data = b"tc-140 regression";
+        let staging = MemoryStaging;
+        let mut stage = staging.stage(&space_id).await.unwrap();
+        futures::io::copy(&mut &data[..], &mut stage).await.unwrap();
+        let hash = ImmutableWriteStore::<MemoryStaging>::persist(&store, &space_id, stage)
+            .await
+            .unwrap();
+
+        assert!(store.contains(&space_id, &hash).await.unwrap());
+        // THE TC-140 ASSERTION: remove of an existing object must succeed (Ok(Some(()))).
+        assert_eq!(store.remove(&space_id, &hash).await.unwrap(), Some(()));
+        // remove-nonexistent must be a clean None, not an error.
+        assert_eq!(store.remove(&space_id, &hash).await.unwrap(), None);
+        assert!(!store.contains(&space_id, &hash).await.unwrap());
     }
 }


### PR DESCRIPTION
Fixes the TC-140 bug where `kv.delete` silently no-ops on overwritten keys on S3-backed nodes, surfacing to SDK clients as `{ok:false, code:"AUTH_UNAUTHORIZED"}`.

## Root cause
`S3BlockStore::remove` (storage/s3.rs) probed object size with `get_object_attributes()` but **never called `.object_attributes(...)`**, so the required `x-amz-object-attributes` header was omitted. The aws-sdk-s3 0.19 builder adds that header only when the field is `Some`, so the request compiled and shipped without it, and S3 rejected **every** call with `400 InvalidRequest` ("the x-amz-object-attributes header ... is either missing or empty"). S3 block deletion had therefore **never** worked in prod.

The only caller is the kv/del side-effect (tinycloud-core db.rs ~659). The delete tombstone is written on the same transaction *before* the side-effect loop, so for an **overwritten** key (>=2 PUTs) `get_kv_entity` returns the older live version W(n-1) and calls `remove()` on its block → the 400 propagates as `TxStoreError::StoreDelete` → `tx.commit()` is never reached → the whole delete rolls back (silent no-op). Single-version keys skip `remove()` (their only row is already tombstoned), which is why the bug only showed on overwritten keys.

Secondary bug: the `/invoke` and `verify_auth` error mappers routed `StoreDelete`/`StoreRead`/`StoreWrite`/`Io` into the `_ => Unauthorized` catch-all, so the S3 `InvalidRequest` surfaced as **HTTP 401**; the js-sdk classifies any 401 as `AUTH_UNAUTHORIZED`. This misled the Listen investigation and can cause SDK clients to nuke valid sessions on storage outages.

## Fix
- **`96511cd`** — probe with `head_object()`, mirroring the proven idiom in `contains` (`NotFound → Ok(None)`); `content_length()` gives the size for `decrement_size`. HeadObject is universally supported by S3-compatibles (minio/R2/localstack) unlike GetObjectAttributes; the prod S3 endpoint is parametrized so this matters. Removes the now-unused `GetObjectAttributes` imports.
- **`683cd52`** — extract `map_invoke_error` shared by `/invoke` and `verify_auth`; `StoreRead|StoreWrite|StoreDelete|Io → 500`. Genuine auth failures arrive as `TxStoreError::Tx(...)` and still hit the 401 catch-all; `SpaceNotFound` stays 404.

## Tests
- Unit (CI): `storage_errors_map_to_500_not_401`, `auth_and_notfound_mappings_unchanged` — lock the mapping in both directions.
- Live (env-gated `#[ignore]`): `s3_remove_lifecycle` in storage/s3.rs — remove-existing succeeds, remove-nonexistent → `Ok(None)`.

## Verification performed
Ran against community `localstack/localstack:3` (3.8.1) with a real S3-compatible endpoint:
- `cargo fmt -- --check`, `RUSTFLAGS=-Dwarnings cargo clippy`, `cargo test` (63 pass, 1 ignored) — all green from `tinycloud-node-server/` as CI does.
- `s3_remove_lifecycle` against localstack: **GREEN** on the fix.
- **Proved the repro**: temporarily reverting `remove()` to `get_object_attributes` (parent behavior) makes `s3_remove_lifecycle` **FAIL** at the `remove().unwrap()` — the buggy probe errors out where the fixed one succeeds. (localstack surfaces the malformed GetObjectAttributes response as `Unhandled("no root element")`; real AWS returns the `InvalidRequest: x-amz-object-attributes` message. Same failing call, same fix.)

## Still needs a real-node / full-stack check (not faked)
The invoke-layer, user-visible E2E was **not** run here because it requires standing up the full js-sdk build pipeline (WASM → node-sdk-wasm → tsup + monorepo install), which is cross-repo and not built in this sandbox. To verify against a real S3-backed node before/after deploy:
1. PUT k=v1, PUT k=v2, DELETE k → delete returns success (was `AUTH_UNAUTHORIZED`); GET k → null.
2. **Observe the known `list`/`metadata` ghost** (do NOT treat as a regression): after deleting an overwritten key, the key still appears in `list()`/`metadata()` via the older untombstoned version, permanently — this is the pre-existing defect tracked in TC-149, made visible by this fix, explicitly out of scope here.
3. Single-version delete → still succeeds; delete of never-written key → still 401 (unchanged).
4. Stop S3, GET an existing key → **HTTP 500** (was 401); restart → works.

## Known hazard, deferred (see follow-ups)
S3 blocks are content-addressed and deduped per space, and `remove()` is unconditional. Now that S3 delete actually works, deleting a key whose content hash is shared by another live key in the same space destroys that other key's data (**cross-key shared-hash data loss**, TC-150). Deferred because a naive refcount guard would reintroduce delete-resurrection under the current latest-only tombstone semantics — the real fix (tombstone-all-versions + refcounted GC) has event-materialization/replication implications and belongs with TC-149/TC-150. **Interim safety:** S3 delete never worked before, so exposure starts at deploy; the only planned new caller (Listen's revocation sweep) deletes unique-content blobs (CIDs/signatures), so no imminent data loss — Listen should confirm sweep-value uniqueness before enabling the sweep.

## Wire / deploy
No response-schema or SDK type change → **no js-sdk rev bump**. The only wire-visible change is storage-outage errors on kv/get,put,del now returning **500 instead of 401** — Listen's sweep should treat 5xx as retryable, not as auth failure. **Deploy ordering:** ship this node fix to `tee.node.tinycloud.xyz` (and `node.tinycloud.xyz`) **before** Listen enables any expired-delegation cleanup sweep that assumes deletes work. Rollback = single `git revert` + redeploy prior image; no state/migration concerns (a rollback merely restores failing deletes; blocks deleted while live stay deleted, their rows tombstoned).

## Follow-ups (filed, hard merge gate)
- TC-149 — kv/del tombstones only the latest version → older versions resurrect in list/metadata.
- TC-150 — cross-key shared content-hash block deletion (data loss) + overwritten-key/single-version block orphans (GC).

Ref: TC-140.


---

## Post-review addenda (Fable code review, verdict: READY-AFTER-REAL-NODE-E2E)

- **Newly reachable partial-state window (inherent to the design, not a regression):** if `delete_object` succeeds and `tx.commit()` then fails, the block is gone from S3 while the tombstone rolls back — the row resurrects pointing at deleted content. Bounded and rare; tracked with the block-lifecycle work in TC-150, and the misleading 401 on commit-failure is TC-152.
- **Live-S3 tests are manual-only:** the env-gated `#[ignore]` suite provably trips on a probe regression but does not run in CI; CI job tracked as TC-153 (repo's `test/docker-compose.yml` localstack is bit-rotted — verification here used native `localstack:3`).
