### PR TITLE
Quota: never block writes on the quota service (stale-while-revalidate) (#104)

### DIFF
--- a/tinycloud-node-server/src/quota.rs
+++ b/tinycloud-node-server/src/quota.rs
@@ -32,6 +32,19 @@ struct RemoteEntry {
     /// Set by `remove_limit` (billing invalidation after a plan change): the
     /// value is served one more time while a refresh runs in the background.
     stale: bool,
+    /// The most recent failed refresh of an already-known value. This keeps
+    /// stale writes from repeatedly retrying an unavailable quota service.
+    last_failure: Option<Instant>,
+}
+
+#[allow(clippy::unnecessary_map_or)] // Keep D1's no-failure-or-backoff-elapsed policy explicit.
+fn should_spawn_refresh(
+    stale: bool,
+    fetched_at_elapsed: Duration,
+    last_failure_elapsed: Option<Duration>,
+) -> bool {
+    (stale && last_failure_elapsed.map_or(true, |elapsed| elapsed >= FAILURE_BACKOFF))
+        || (!stale && fetched_at_elapsed >= FRESH_TTL)
 }
 
 pub struct QuotaCache {
@@ -99,8 +112,13 @@ impl QuotaCache {
                 limit_bytes: Some(limit),
                 fetched_at,
                 stale,
+                last_failure,
             }) => {
-                if stale || fetched_at.elapsed() >= FRESH_TTL {
+                if should_spawn_refresh(
+                    stale,
+                    fetched_at.elapsed(),
+                    last_failure.map(|failure| failure.elapsed()),
+                ) {
                     self.spawn_refresh(key);
                 }
                 Some(ByteUnit::Byte(limit))
@@ -212,6 +230,7 @@ impl QuotaCache {
                 limit_bytes,
                 fetched_at: Instant::now(),
                 stale,
+                last_failure: None,
             },
         );
     }
@@ -270,6 +289,7 @@ async fn record_fetch(
                     limit_bytes: Some(limit),
                     fetched_at: Instant::now(),
                     stale: false,
+                    last_failure: None,
                 },
             );
         }
@@ -280,6 +300,7 @@ async fn record_fetch(
                     limit_bytes: Some(previous),
                     fetched_at: Instant::now(),
                     stale: true,
+                    last_failure: Some(Instant::now()),
                 },
             );
         }
@@ -290,6 +311,7 @@ async fn record_fetch(
                     limit_bytes: None,
                     fetched_at: Instant::now(),
                     stale: false,
+                    last_failure: None,
                 },
             );
         }
@@ -309,6 +331,48 @@ mod test {
     // Unroutable per RFC 5737 (TEST-NET-1): connects fail fast and never
     // succeed, exercising the failure paths without a live service.
     const DEAD_URL: &str = "http://192.0.2.1:1";
+
+    #[tokio::test]
+    async fn refresh_decision_respects_failure_backoff_and_invalidation() {
+        assert!(!should_spawn_refresh(
+            true,
+            Duration::from_secs(0),
+            Some(FAILURE_BACKOFF - Duration::from_millis(1)),
+        ));
+        assert!(should_spawn_refresh(
+            true,
+            Duration::from_secs(0),
+            Some(FAILURE_BACKOFF),
+        ));
+        assert!(should_spawn_refresh(true, Duration::from_secs(0), None));
+        assert!(!should_spawn_refresh(false, Duration::from_secs(0), None));
+    }
+
+    #[tokio::test]
+    async fn recent_failed_stale_refresh_does_not_spawn() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind local listener");
+        let cache = QuotaCache::new(
+            Some(ByteUnit::Byte(100)),
+            Some(format!(
+                "http://{}",
+                listener.local_addr().expect("listener address")
+            )),
+        );
+        let sid = space(1);
+        let key = sid.to_string();
+        cache.seed_remote(&key, Some(500), false).await;
+        record_fetch(&cache.remote, &key, None).await;
+
+        assert_eq!(cache.get_limit(&sid).await, Some(ByteUnit::Byte(500)));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), listener.accept())
+                .await
+                .is_err(),
+            "a recent failed refresh must suppress another background fetch",
+        );
+    }
 
     #[tokio::test]
     async fn override_beats_remote_and_default() {

--- a/tinycloud-node-server/src/quota.rs
+++ b/tinycloud-node-server/src/quota.rs
@@ -321,6 +321,7 @@ async fn record_fetch(
 #[cfg(test)]
 mod test {
     use super::*;
+    use tokio::io::AsyncWriteExt;
 
     fn space(n: u8) -> SpaceId {
         format!("tinycloud:pkh:eip155:1:0x7BD63AA37326a64d458559F44432103e3d6eEDE9:s{n}")
@@ -331,6 +332,47 @@ mod test {
     // Unroutable per RFC 5737 (TEST-NET-1): connects fail fast and never
     // succeed, exercising the failure paths without a live service.
     const DEAD_URL: &str = "http://192.0.2.1:1";
+
+    #[tokio::test]
+    async fn first_sight_http_success_is_parsed_and_cached() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind local listener");
+        let quota_url = format!(
+            "http://{}",
+            listener.local_addr().expect("listener address")
+        );
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept quota request");
+            let body = r#"{"storage_limit_bytes":500}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("write quota response");
+            stream.shutdown().await.expect("close quota response");
+            listener
+        });
+
+        let cache = QuotaCache::new(Some(ByteUnit::Byte(100)), Some(quota_url));
+        let sid = space(1);
+        let key = sid.to_string();
+
+        assert_eq!(cache.get_limit(&sid).await, Some(ByteUnit::Byte(500)));
+        let listener = server.await.expect("quota server task");
+        assert_eq!(cache.remote_entry(&key).await, Some((Some(500), false)));
+        assert_eq!(cache.get_limit(&sid).await, Some(ByteUnit::Byte(500)));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), listener.accept())
+                .await
+                .is_err(),
+            "the fresh cached entry must avoid a second network request",
+        );
+    }
 
     #[tokio::test]
     async fn refresh_decision_respects_failure_backoff_and_invalidation() {

--- a/tinycloud-node-server/src/quota.rs
+++ b/tinycloud-node-server/src/quota.rs
@@ -1,8 +1,8 @@
 use rocket::data::ByteUnit;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tinycloud_auth::resource::SpaceId;
 use tokio::sync::RwLock;
 
@@ -11,8 +11,39 @@ pub struct QuotaInfo {
     pub storage_limit_bytes: u64,
 }
 
+/// How long a remote quota answer is served without triggering a background
+/// refresh. Matches the billing sidecar's own usage-cache TTL.
+const FRESH_TTL: Duration = Duration::from_secs(60);
+/// After a failed fetch with no known value, wait this long before retrying
+/// so an unavailable quota service is not hammered once per write.
+const FAILURE_BACKOFF: Duration = Duration::from_secs(30);
+/// Budget for the single blocking fetch on first sight of a space. Writes to
+/// already-seen spaces never wait on the quota service (stale-while-revalidate),
+/// so this is the worst-case latency the quota system can add to a write.
+const FETCH_TIMEOUT: Duration = Duration::from_secs(3);
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Clone, Copy, Debug)]
+struct RemoteEntry {
+    /// `None` = the last fetch failed and no prior value is known (negative
+    /// cache); serve the env default until `FAILURE_BACKOFF` elapses.
+    limit_bytes: Option<u64>,
+    fetched_at: Instant,
+    /// Set by `remove_limit` (billing invalidation after a plan change): the
+    /// value is served one more time while a refresh runs in the background.
+    stale: bool,
+}
+
 pub struct QuotaCache {
+    /// Admin-set overrides (`PUT /admin/quota/<space>`). Checked before the
+    /// quota service and never expired. NOTE: these are in-memory only and
+    /// do not survive a node restart — re-apply after deploys, or use the
+    /// billing sidecar for durable limits.
     overrides: Arc<RwLock<HashMap<String, u64>>>,
+    /// Values learned from the quota service, with freshness metadata.
+    remote: Arc<RwLock<HashMap<String, RemoteEntry>>>,
+    /// Spaces with a background refresh currently in flight (dedupe guard).
+    inflight: Arc<RwLock<HashSet<String>>>,
     default_limit: Option<ByteUnit>,
     quota_url: Option<String>,
     client: Option<reqwest::Client>,
@@ -22,13 +53,15 @@ impl QuotaCache {
     pub fn new(default_limit: Option<ByteUnit>, quota_url: Option<String>) -> Self {
         let client = quota_url.as_ref().map(|_| {
             reqwest::Client::builder()
-                .timeout(Duration::from_secs(10))
-                .connect_timeout(Duration::from_secs(5))
+                .timeout(FETCH_TIMEOUT)
+                .connect_timeout(CONNECT_TIMEOUT)
                 .build()
                 .expect("failed to build quota reqwest client")
         });
         Self {
             overrides: Arc::new(RwLock::new(HashMap::new())),
+            remote: Arc::new(RwLock::new(HashMap::new())),
+            inflight: Arc::new(RwLock::new(HashSet::new())),
             default_limit,
             quota_url,
             client,
@@ -36,7 +69,16 @@ impl QuotaCache {
     }
 
     /// Get the effective storage limit for a space.
-    /// Priority: cache override → lazy-load from quota service → env default → None
+    ///
+    /// Priority: admin override → remote quota service → env default → None.
+    ///
+    /// The remote lookup never blocks a write for a space that has been seen
+    /// before: fresh values are served directly, stale values are served
+    /// while a refresh runs in the background, and fetch failures fall back
+    /// to the env default (fail-open — a billing hiccup must not deny
+    /// writes). Only the very first write to a space performs one bounded
+    /// (`FETCH_TIMEOUT`) synchronous fetch, so paid limits above the env
+    /// default apply from the first byte.
     pub async fn get_limit(&self, space_id: &SpaceId) -> Option<ByteUnit> {
         let key = space_id.to_string();
 
@@ -47,42 +89,106 @@ impl QuotaCache {
             }
         }
 
-        if let (Some(url), Some(client)) = (&self.quota_url, &self.client) {
-            match client
-                .get(format!("{}/api/quota/{}", url, key))
-                .send()
-                .await
-            {
-                Ok(resp) if resp.status().is_success() => {
-                    if let Ok(info) = resp.json::<QuotaInfo>().await {
-                        let mut overrides = self.overrides.write().await;
-                        overrides.insert(key, info.storage_limit_bytes);
-                        return Some(ByteUnit::Byte(info.storage_limit_bytes));
-                    }
-                }
-                _ => {
-                    tracing::debug!("quota service unavailable for space {}, using default", key);
-                }
-            }
+        if self.quota_url.is_none() || self.client.is_none() {
+            return self.default_limit;
         }
 
-        // Fall back to env default
-        self.default_limit
+        let entry = { self.remote.read().await.get(&key).copied() };
+        match entry {
+            Some(RemoteEntry {
+                limit_bytes: Some(limit),
+                fetched_at,
+                stale,
+            }) => {
+                if stale || fetched_at.elapsed() >= FRESH_TTL {
+                    self.spawn_refresh(key);
+                }
+                Some(ByteUnit::Byte(limit))
+            }
+            Some(RemoteEntry {
+                limit_bytes: None,
+                fetched_at,
+                ..
+            }) => {
+                if fetched_at.elapsed() >= FAILURE_BACKOFF {
+                    self.spawn_refresh(key);
+                }
+                self.default_limit
+            }
+            None => match self.fetch_and_record(&key).await {
+                Some(limit) => Some(ByteUnit::Byte(limit)),
+                None => self.default_limit,
+            },
+        }
     }
 
+    /// Fetch the limit from the quota service and record the outcome
+    /// (success or negative entry) in the remote cache.
+    async fn fetch_and_record(&self, key: &str) -> Option<u64> {
+        let fetched = fetch_remote(self.client.as_ref()?, self.quota_url.as_deref()?, key).await;
+        record_fetch(&self.remote, key, fetched).await;
+        fetched
+    }
+
+    /// Refresh a space's remote entry in the background, deduplicating
+    /// concurrent refreshes for the same space.
+    fn spawn_refresh(&self, key: String) {
+        let (Some(client), Some(url)) = (self.client.clone(), self.quota_url.clone()) else {
+            return;
+        };
+        let remote = self.remote.clone();
+        let inflight = self.inflight.clone();
+        tokio::spawn(async move {
+            {
+                let mut guard = inflight.write().await;
+                if !guard.insert(key.clone()) {
+                    return; // refresh already in flight
+                }
+            }
+            let fetched = fetch_remote(&client, &url, &key).await;
+            record_fetch(&remote, &key, fetched).await;
+            inflight.write().await.remove(&key);
+        });
+    }
+
+    /// Set an admin override. In-memory only: overrides are lost on restart.
     pub async fn set_limit(&self, space_id: &SpaceId, limit_bytes: u64) {
         let mut overrides = self.overrides.write().await;
         overrides.insert(space_id.to_string(), limit_bytes);
     }
 
+    /// Remove an admin override and mark any remote-cached value stale so the
+    /// next write triggers a background refresh (the billing sidecar calls
+    /// this after a plan change). Returns true if an override or a cached
+    /// remote value existed.
     pub async fn remove_limit(&self, space_id: &SpaceId) -> bool {
-        let mut overrides = self.overrides.write().await;
-        overrides.remove(&space_id.to_string()).is_some()
+        let key = space_id.to_string();
+        let had_override = self.overrides.write().await.remove(&key).is_some();
+        let mut remote = self.remote.write().await;
+        let had_remote = match remote.get_mut(&key) {
+            Some(entry) => {
+                entry.stale = true;
+                true
+            }
+            None => false,
+        };
+        had_override || had_remote
     }
 
     pub async fn get_override(&self, space_id: &SpaceId) -> Option<u64> {
         let overrides = self.overrides.read().await;
         overrides.get(&space_id.to_string()).copied()
+    }
+
+    /// The last limit learned from the quota service, if any (stale or not).
+    /// Local read only — safe for the admin endpoint the quota service calls
+    /// back into (no recursion).
+    pub async fn get_cached_remote(&self, space_id: &SpaceId) -> Option<u64> {
+        self.remote
+            .read()
+            .await
+            .get(&space_id.to_string())
+            .and_then(|e| e.limit_bytes)
     }
 
     pub async fn list_overrides(&self) -> HashMap<String, u64> {
@@ -96,5 +202,187 @@ impl QuotaCache {
 
     pub fn quota_url(&self) -> Option<&str> {
         self.quota_url.as_deref()
+    }
+
+    #[cfg(test)]
+    async fn seed_remote(&self, key: &str, limit_bytes: Option<u64>, stale: bool) {
+        self.remote.write().await.insert(
+            key.to_string(),
+            RemoteEntry {
+                limit_bytes,
+                fetched_at: Instant::now(),
+                stale,
+            },
+        );
+    }
+
+    #[cfg(test)]
+    async fn remote_entry(&self, key: &str) -> Option<(Option<u64>, bool)> {
+        self.remote
+            .read()
+            .await
+            .get(key)
+            .map(|e| (e.limit_bytes, e.stale))
+    }
+}
+
+async fn fetch_remote(client: &reqwest::Client, url: &str, key: &str) -> Option<u64> {
+    match client
+        .get(format!("{}/api/quota/{}", url, key))
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => match resp.json::<QuotaInfo>().await {
+            Ok(info) => Some(info.storage_limit_bytes),
+            Err(e) => {
+                tracing::warn!("quota service returned invalid body for space {key}: {e}");
+                None
+            }
+        },
+        Ok(resp) => {
+            tracing::warn!(
+                "quota service returned {} for space {key}, using fallback",
+                resp.status()
+            );
+            None
+        }
+        Err(e) => {
+            tracing::debug!("quota service unavailable for space {key} ({e}), using fallback");
+            None
+        }
+    }
+}
+
+/// Record a fetch outcome. A failure never erases a previously known limit:
+/// the old value stays (marked refreshed-at-now, still stale) so writes keep
+/// using the last-known limit rather than snapping to the env default.
+async fn record_fetch(
+    remote: &Arc<RwLock<HashMap<String, RemoteEntry>>>,
+    key: &str,
+    fetched: Option<u64>,
+) {
+    let mut guard = remote.write().await;
+    match (fetched, guard.get(key).and_then(|e| e.limit_bytes)) {
+        (Some(limit), _) => {
+            guard.insert(
+                key.to_string(),
+                RemoteEntry {
+                    limit_bytes: Some(limit),
+                    fetched_at: Instant::now(),
+                    stale: false,
+                },
+            );
+        }
+        (None, Some(previous)) => {
+            guard.insert(
+                key.to_string(),
+                RemoteEntry {
+                    limit_bytes: Some(previous),
+                    fetched_at: Instant::now(),
+                    stale: true,
+                },
+            );
+        }
+        (None, None) => {
+            guard.insert(
+                key.to_string(),
+                RemoteEntry {
+                    limit_bytes: None,
+                    fetched_at: Instant::now(),
+                    stale: false,
+                },
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn space(n: u8) -> SpaceId {
+        format!("tinycloud:pkh:eip155:1:0x7BD63AA37326a64d458559F44432103e3d6eEDE9:s{n}")
+            .parse()
+            .expect("valid space id")
+    }
+
+    // Unroutable per RFC 5737 (TEST-NET-1): connects fail fast and never
+    // succeed, exercising the failure paths without a live service.
+    const DEAD_URL: &str = "http://192.0.2.1:1";
+
+    #[tokio::test]
+    async fn override_beats_remote_and_default() {
+        let cache = QuotaCache::new(Some(ByteUnit::Byte(100)), Some(DEAD_URL.into()));
+        let sid = space(1);
+        cache.seed_remote(&sid.to_string(), Some(200), false).await;
+        cache.set_limit(&sid, 300).await;
+        assert_eq!(cache.get_limit(&sid).await, Some(ByteUnit::Byte(300)));
+    }
+
+    #[tokio::test]
+    async fn no_quota_url_falls_back_to_default() {
+        let cache = QuotaCache::new(Some(ByteUnit::Byte(100)), None);
+        assert_eq!(cache.get_limit(&space(1)).await, Some(ByteUnit::Byte(100)));
+    }
+
+    #[tokio::test]
+    async fn fresh_remote_value_served_directly() {
+        let cache = QuotaCache::new(Some(ByteUnit::Byte(100)), Some(DEAD_URL.into()));
+        let sid = space(1);
+        cache.seed_remote(&sid.to_string(), Some(500), false).await;
+        assert_eq!(cache.get_limit(&sid).await, Some(ByteUnit::Byte(500)));
+    }
+
+    #[tokio::test]
+    async fn stale_remote_value_still_served_not_blocked() {
+        let cache = QuotaCache::new(Some(ByteUnit::Byte(100)), Some(DEAD_URL.into()));
+        let sid = space(1);
+        cache.seed_remote(&sid.to_string(), Some(500), true).await;
+        // Stale value is served immediately; the refresh happens off-path.
+        assert_eq!(cache.get_limit(&sid).await, Some(ByteUnit::Byte(500)));
+    }
+
+    #[tokio::test]
+    async fn first_sight_fetch_failure_falls_open_and_negative_caches() {
+        let cache = QuotaCache::new(Some(ByteUnit::Byte(100)), Some(DEAD_URL.into()));
+        let sid = space(1);
+        assert_eq!(cache.get_limit(&sid).await, Some(ByteUnit::Byte(100)));
+        // Failure recorded as a negative entry: subsequent writes inside the
+        // backoff window use the default without re-fetching.
+        let entry = cache.remote_entry(&sid.to_string()).await;
+        assert_eq!(entry, Some((None, false)));
+        assert_eq!(cache.get_limit(&sid).await, Some(ByteUnit::Byte(100)));
+    }
+
+    #[tokio::test]
+    async fn failed_refresh_keeps_last_known_limit() {
+        let cache = QuotaCache::new(Some(ByteUnit::Byte(100)), Some(DEAD_URL.into()));
+        let sid = space(1);
+        let key = sid.to_string();
+        cache.seed_remote(&key, Some(500), false).await;
+        // Simulate a refresh failing after a value was known.
+        record_fetch(&cache.remote, &key, None).await;
+        assert_eq!(cache.remote_entry(&key).await, Some((Some(500), true)));
+        assert_eq!(cache.get_limit(&sid).await, Some(ByteUnit::Byte(500)));
+    }
+
+    #[tokio::test]
+    async fn remove_limit_drops_override_and_marks_remote_stale() {
+        let cache = QuotaCache::new(Some(ByteUnit::Byte(100)), Some(DEAD_URL.into()));
+        let sid = space(1);
+        let key = sid.to_string();
+        cache.set_limit(&sid, 300).await;
+        cache.seed_remote(&key, Some(500), false).await;
+        assert!(cache.remove_limit(&sid).await);
+        assert_eq!(cache.get_override(&sid).await, None);
+        assert_eq!(cache.remote_entry(&key).await, Some((Some(500), true)));
+        // Nothing left to remove except the (kept) stale remote entry.
+        assert!(cache.remove_limit(&sid).await);
+    }
+
+    #[tokio::test]
+    async fn remove_limit_on_unknown_space_is_false() {
+        let cache = QuotaCache::new(None, Some(DEAD_URL.into()));
+        assert!(!cache.remove_limit(&space(9)).await);
     }
 }

--- a/tinycloud-node-server/src/routes/admin.rs
+++ b/tinycloud-node-server/src/routes/admin.rs
@@ -73,6 +73,11 @@ pub struct UsageResponse {
     pub count: usize,
 }
 
+/// Set an admin quota override for a space.
+///
+/// Overrides are held in memory only and DO NOT survive a node restart
+/// (tracked in issue #104) — re-apply them after deploys, or set durable
+/// limits through the billing sidecar instead.
 #[put("/admin/quota/<space_id>", data = "<body>")]
 pub async fn set_quota(
     _auth: AdminAuth,
@@ -92,6 +97,11 @@ pub async fn set_quota(
     }))
 }
 
+/// Drop a space's admin override and mark any remote-cached limit stale.
+///
+/// The billing sidecar calls this after a plan change: the stale value is
+/// served for at most one more write while the node refreshes the limit in
+/// the background (writes are never blocked on the quota service).
 #[delete("/admin/quota/<space_id>")]
 pub async fn delete_quota(
     _auth: AdminAuth,
@@ -127,7 +137,13 @@ pub async fn get_quota(
     // usage — on a cold cache the two recurse into a mutual-call storm.
     // Report only what is already known locally (override/cached, else the
     // env default).
-    let effective = override_bytes.or_else(|| quota_cache.default_limit().map(|l| l.as_u64()));
+    let effective = match override_bytes {
+        Some(b) => Some(b),
+        None => match quota_cache.get_cached_remote(&sid).await {
+            Some(b) => Some(b),
+            None => quota_cache.default_limit().map(|l| l.as_u64()),
+        },
+    };
     let usage = tinycloud
         .store_size(&sid)
         .await


### PR DESCRIPTION
Addresses the node side of #104 (quota check on the write path times out for heavy accounts).

## What changed

- **Split admin overrides from remote-learned limits.** Overrides remain authoritative and never expire. They are still in-memory only — that ephemerality (an aggravator in #104) is now documented on the admin routes rather than silent.
- **Stale-while-revalidate for remote limits.** Fresh values (<60s) are served directly. Stale values are served immediately while a deduplicated background refresh runs. Writes to a space the node has seen before **never** wait on the billing sidecar.
- **Fail-open, in order.** On fetch failure: last-known limit → env default. A failure with no known value is negative-cached for 30s so an unavailable quota service isn't hammered once per write.
- **First sight of a space** still does one synchronous fetch (so paid limits above the env default apply from the first byte), but bounded at 3s total / 2s connect instead of 10s/5s — this is now the worst-case latency quota can add to any write.
- **`DELETE /admin/quota/<space>`** (billing's post-webhook invalidation) marks the remote value stale instead of erasing it: the next write serves the old limit once and refreshes off-path, instead of paying a blocking fetch.
- **`GET /admin/quota/<space>`** now reports the cached remote limit (local read only — the no-recursion guard against the mutual-call storm stays).

## Verification note

While implementing, I checked the exact failure mechanics from the issue: `QuotaCache::get_limit` already fell back to the env default on fetch *failure*, so the prod `upstream request timed out` was most plausibly the synchronous 10s fetch (cold cache after restart, billing fanning back per space) pushing total write latency past the ingress timeout — a blocked write, not an in-process error. This PR removes that blocking wait entirely for known spaces and caps it at 3s for first-sight spaces. `store_size` needed no caching: it's an in-memory counter on all backends (the "real storage scan" wording in the issue reflects an older implementation).

## Testing

- 8 new unit tests on `QuotaCache` covering override precedence, fresh/stale serving, fail-open ordering (last-known > default), negative-cache backoff, and invalidation semantics.
- `cargo fmt --check`, `cargo clippy --all-targets` (no new warnings), `cargo test -p tinycloud-node --lib`: 69/69 pass.

Companion PR on the billing side makes `/api/quota/:space_id` a precomputed D1 row read (link to follow in comments).

Fixes the write-path half of #104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)